### PR TITLE
ListChoiceGroupStyle

### DIFF
--- a/Sources/Orbit/Components/ListChoice.swift
+++ b/Sources/Orbit/Components/ListChoice.swift
@@ -26,7 +26,6 @@ public struct ListChoice<Content: View>: View {
     let description: String
     let icon: Icon.Content
     let disclosure: ListChoiceDisclosure
-    let backgroundColor: BackgroundColor?
     let showSeparator: Bool
     let action: () -> Void
     let content: () -> Content
@@ -41,7 +40,7 @@ public struct ListChoice<Content: View>: View {
                 buttonContent
             }
         )
-        .buttonStyle(ListChoiceButtonStyle(backgroundColor: backgroundColor))
+        .buttonStyle(ListChoiceButtonStyle())
         .accessibility(label: SwiftUI.Text(title))
         .accessibility(hint: SwiftUI.Text(description))
     }
@@ -132,7 +131,6 @@ public extension ListChoice {
         description: String = "",
         icon: Icon.Content,
         disclosure: ListChoiceDisclosure = .disclosure(),
-        backgroundColor: BackgroundColor? = nil,
         showSeparator: Bool = true,
         action: @escaping () -> Void = {},
         @ViewBuilder content: @escaping () -> Content
@@ -141,7 +139,6 @@ public extension ListChoice {
         self.description = description
         self.icon = icon
         self.disclosure = disclosure
-        self.backgroundColor = backgroundColor
         self.showSeparator = showSeparator
         self.action = action
         self.content = content
@@ -153,7 +150,6 @@ public extension ListChoice {
         description: String = "",
         icon: Icon.Symbol = .none,
         disclosure: ListChoiceDisclosure = .disclosure(),
-        backgroundColor: BackgroundColor? = nil,
         showSeparator: Bool = true,
         action: @escaping () -> Void = {},
         @ViewBuilder content: @escaping () -> Content
@@ -163,7 +159,6 @@ public extension ListChoice {
             description: description,
             icon: .icon(icon, size: .default, color: .inkNormal),
             disclosure: disclosure,
-            backgroundColor: backgroundColor,
             showSeparator: showSeparator,
             action: action,
             content: content
@@ -176,7 +171,6 @@ public extension ListChoice {
         description: String = "",
         icon: Icon.Content,
         disclosure: ListChoiceDisclosure = .disclosure(),
-        backgroundColor: BackgroundColor? = nil,
         showSeparator: Bool = true,
         action: @escaping () -> Void = {}
     ) where Content == EmptyView {
@@ -185,7 +179,6 @@ public extension ListChoice {
             description: description,
             icon: icon,
             disclosure: disclosure,
-            backgroundColor: backgroundColor,
             showSeparator: showSeparator,
             action: action,
             content: { EmptyView() }
@@ -198,7 +191,6 @@ public extension ListChoice {
         description: String = "",
         icon: Icon.Symbol = .none,
         disclosure: ListChoiceDisclosure = .disclosure(),
-        backgroundColor: BackgroundColor? = nil,
         showSeparator: Bool = true,
         action: @escaping () -> Void = {}
     ) where Content == EmptyView {
@@ -207,7 +199,6 @@ public extension ListChoice {
             description: description,
             icon: .icon(icon, size: .default, color: .inkNormal),
             disclosure: disclosure,
-            backgroundColor: backgroundColor,
             showSeparator: showSeparator,
             action: action
         )
@@ -226,24 +217,16 @@ extension ListChoice {
     // Solves the touch-down, touch-up animations that would otherwise need gesture avoidance logic.
     struct ListChoiceButtonStyle: SwiftUI.ButtonStyle {
 
-        let backgroundColor: ListChoice.BackgroundColor?
-
-        public init(backgroundColor: ListChoice.BackgroundColor? = nil) {
-            self.backgroundColor = backgroundColor
-        }
-
-        public func makeBody(configuration: Configuration) -> some View {
+        func makeBody(configuration: Configuration) -> some View {
             configuration.label
-                .background(backgroundColor(isPressed: configuration.isPressed))
+                .background(
+                    backgroundColor(isPressed: configuration.isPressed)
+                        .contentShape(Rectangle())
+                )
         }
 
         func backgroundColor(isPressed: Bool) -> Color {
-            switch (backgroundColor, isPressed) {
-                case (let backgroundColor?, true):          return backgroundColor.active
-                case (let backgroundColor?, false):         return backgroundColor.normal
-                case (.none, true):                         return .whiteHover
-                case (.none, false):                        return .white
-            }
+            isPressed ? .inkLight.opacity(0.2) : .clear
         }
     }
 }
@@ -257,6 +240,7 @@ struct ListChoicePreviews: PreviewProvider {
             chevron
             button
             checkbox
+            white
         }
         .background(Color.cloudLight.opacity(0.8))
         .previewLayout(.sizeThatFits)
@@ -327,5 +311,28 @@ struct ListChoicePreviews: PreviewProvider {
         }
         .padding()
         .previewDisplayName("Checkbox")
+    }
+    
+    static var white: some View {
+        VStack(spacing: .small) {
+            ListChoice(title, disclosure: .none)
+                .background(Color.white)
+            ListChoice(title, description: description, disclosure: .none)
+                .background(Color.white)
+            ListChoice(title, description: "No Separator", disclosure: .none, showSeparator: false)
+                .background(Color.white)
+            ListChoice(title, icon: .airplane, disclosure: .none)
+                .background(Color.white)
+            ListChoice(title, icon: .icon(.airplane, size: .medium, color: .inkLighter), disclosure: .none)
+                .background(Color.white)
+            ListChoice(title, description: description, icon: .airplane, disclosure: .none)
+                .background(Color.white)
+            ListChoice(title, description: description, disclosure: .none) {
+                customContentPlaceholder
+            }
+            .background(Color.white)
+        }
+        .padding()
+        .previewDisplayName("White background")
     }
 }

--- a/Sources/Orbit/Components/ListChoiceGroup.swift
+++ b/Sources/Orbit/Components/ListChoiceGroup.swift
@@ -1,5 +1,14 @@
 import SwiftUI
 
+public enum ListChoiceGroupStyle {
+    
+    // Style with no decoration.
+    case borderless
+    
+    // Style with Card-like appearance.
+    case card(status: Status? = nil, backgroundColor: Color = .white)
+}
+
 /// Wraps ListChoice items.
 
 /// - Related components:
@@ -11,14 +20,35 @@ public struct ListChoiceGroup<Content: View>: View {
 
     @Environment(\.horizontalSizeClass) var horizontalSizeClass
 
-    let status: Status?
-    let backgroundColor: Color?
+    let title: String
+    let iconContent: Icon.Content
+    let style: ListChoiceGroupStyle
+    let titleStyle: Header.TitleStyle
     let content: () -> Content
 
     public var body: some View {
-        Card(spacing: 0, padding: 0, style: .iOS, status: status, backgroundColor: backgroundColor) {
-            content()
+        switch style {
+            case .card(let status, let backgroundColor):
+                Card(title, spacing: 0, padding: 0, style: .iOS, status: status, backgroundColor: backgroundColor) {
+                    content()
+                }
+            case .borderless:
+                borderlessView
         }
+    }
+    
+    var borderlessView: some View {
+        VStack(alignment: .leading, spacing: .xSmall) {
+            Header(title, iconContent: iconContent, titleStyle: titleStyle)
+                .padding([.horizontal, .top], .medium)
+
+            VStack(alignment: .leading, spacing: 0) {
+                content()
+            }
+        }
+        .frame(maxWidth: Layout.readableMaxWidth, alignment: .leading)
+        .frame(maxWidth: .infinity)
+        .padding(.horizontal, horizontalSizeClass == .regular ? .medium : 0)
     }
 }
 
@@ -27,12 +57,31 @@ public extension ListChoiceGroup {
     
     /// Creates Orbit ListChoiceGroup wrapper component.
     init(
-        status: Status? = nil,
-        backgroundColor: Color? = nil,
+        _ title: String = "",
+        icon: Icon.Symbol = .none,
+        style: ListChoiceGroupStyle = .card(),
+        titleStyle: Header.TitleStyle = .title3,
         @ViewBuilder content: @escaping () -> Content
     ) {
-        self.status = status
-        self.backgroundColor = backgroundColor
+        self.title = title
+        self.iconContent = .icon(icon, size: .header(titleStyle))
+        self.style = style
+        self.titleStyle = titleStyle
+        self.content = content
+    }
+    
+    /// Creates Orbit ListChoiceGroup wrapper component.
+    init(
+        _ title: String = "",
+        iconContent: Icon.Content,
+        style: ListChoiceGroupStyle = .card(),
+        titleStyle: Header.TitleStyle = .title3,
+        @ViewBuilder content: @escaping () -> Content
+    ) {
+        self.title = title
+        self.iconContent = iconContent
+        self.style = style
+        self.titleStyle = titleStyle
         self.content = content
     }
 }
@@ -47,48 +96,86 @@ struct ListChoiceGroupPreviews: PreviewProvider {
 
     static var previews: some View {
         PreviewWrapper {
-            snapshotsIOS
-            snapshotsIOSRegular
-            snapshotsIOSRegularNarrow
+            snapshotsCard
+            snapshotsCardRegular
+            snapshotsCardRegularNarrow
+            snapshotsBorderless
+            snapshotsBorderlessRegular
+            snapshotsBorderlessRegularNarrow
         }
         .previewLayout(.sizeThatFits)
     }
 
     static var figma: some View {
-        listChoiceGroups
+        listChoiceGroupsCard
             .previewLayout(.sizeThatFits)
             .previewDisplayName("Figma")
     }
 
-    static var snapshotsIOS: some View {
-        listChoiceGroups
+    static var snapshotsCard: some View {
+        listChoiceGroupsCard
             .background(Color.cloudLight)
-            .previewDisplayName("Style - iOS")
+            .previewDisplayName("Style - Card")
     }
 
-    static var snapshotsIOSRegular: some View {
-        listChoiceGroups
+    static var snapshotsCardRegular: some View {
+        listChoiceGroupsCard
             .background(Color.cloudLight)
             .environment(\.horizontalSizeClass, .regular)
             .frame(width: Layout.readableMaxWidth + 100)
-            .previewDisplayName("Style - iOS Regular")
+            .previewDisplayName("Style - Card Regular")
     }
 
-    static var snapshotsIOSRegularNarrow: some View {
-        listChoiceGroups
+    static var snapshotsCardRegularNarrow: some View {
+        listChoiceGroupsCard
             .background(Color.cloudLight)
             .environment(\.horizontalSizeClass, .regular)
             .frame(width: Layout.readableMaxWidth - 200)
-            .previewDisplayName("Style - iOS Regular narrow")
+            .previewDisplayName("Style - Card Regular narrow")
+    }
+    
+    static var snapshotsBorderless: some View {
+        listChoiceGroupsBorderless
+            .background(Color.cloudLight)
+            .previewDisplayName("Style - Borderless")
     }
 
-    static var listChoiceGroups: some View {
+    static var snapshotsBorderlessRegular: some View {
+        listChoiceGroupsBorderless
+            .background(Color.cloudLight)
+            .environment(\.horizontalSizeClass, .regular)
+            .frame(width: Layout.readableMaxWidth + 100)
+            .previewDisplayName("Style - Borderless Regular")
+    }
+
+    static var snapshotsBorderlessRegularNarrow: some View {
+        listChoiceGroupsBorderless
+            .background(Color.cloudLight)
+            .environment(\.horizontalSizeClass, .regular)
+            .frame(width: Layout.readableMaxWidth - 200)
+            .previewDisplayName("Style - Borderless Regular narrow")
+    }
+
+    static var listChoiceGroupsCard: some View {
         VStack(spacing: .medium) {
             ListChoiceGroup {
                 listChoices
             }
 
-            ListChoiceGroup(status: .critical) {
+            ListChoiceGroup(style: .card(status: .critical)) {
+                listChoices
+            }
+        }
+        .padding(.vertical)
+    }
+    
+    static var listChoiceGroupsBorderless: some View {
+        VStack(spacing: .medium) {
+            ListChoiceGroup(style: .borderless) {
+                listChoices
+            }
+            
+            ListChoiceGroup("Group Title", style: .borderless) {
                 listChoices
             }
         }
@@ -96,10 +183,10 @@ struct ListChoiceGroupPreviews: PreviewProvider {
     }
 
     @ViewBuilder static var listChoices: some View {
-        ListChoice("Title")
+        ListChoice("Choice Title")
 
-        ListChoice("Title", icon: .notification)
+        ListChoice("Choice Title", icon: .notification)
 
-        ListChoice("Title", description: description, icon: .airplane)
+        ListChoice("Choice Title", description: description, icon: .airplane)
     }
 }


### PR DESCRIPTION
There are two styles - `card`, which does what `ListChoiceGroup` did previously by default and `borderless`, which is also stripped down from `Card`, but has no borders/corner radius and always has white background.

Also added an optional `title` to `ListChoiceGroup`.

<img width="473" alt="Screenshot 2022-02-04 at 12 52 46" src="https://user-images.githubusercontent.com/12349477/152524720-4965bdb7-0b9b-499e-b6aa-cb9f4d6ad8c6.png">



