### PR TITLE
Add `value` text view to `ListChoice`

### DIFF
--- a/Sources/Orbit/Components/ListChoice.swift
+++ b/Sources/Orbit/Components/ListChoice.swift
@@ -25,6 +25,7 @@ public struct ListChoice<Content: View>: View {
     let title: String
     let description: String
     let icon: Icon.Content
+    let value: String
     let disclosure: ListChoiceDisclosure
     let showSeparator: Bool
     let action: () -> Void
@@ -48,14 +49,17 @@ public struct ListChoice<Content: View>: View {
     var buttonContent: some View {
         HStack(spacing: 0) {
             VStack(alignment: .leading, spacing: 0) {
-                header
+                HStack(spacing: .xSmall) {
+                    header
+                    Spacer(minLength: 0)
+                    Text(value)
+                        .padding(.trailing, valuePadding)
+                }
                 content()
             }
             
-            Spacer(minLength: 0)
-            
             Strut(height: 48)
-
+            
             disclosureView
                 .padding(.trailing, .medium)
         }
@@ -120,6 +124,14 @@ public struct ListChoice<Content: View>: View {
     var headerTextPadding: CGFloat {
         title.isEmpty || description.isEmpty ? .medium : .small
     }
+    
+    var valuePadding: CGFloat {
+        if case .disclosure = disclosure {
+            return 0
+        } else {
+            return .xSmall
+        }
+    }
 }
 
 // MARK: - Inits
@@ -130,6 +142,7 @@ public extension ListChoice {
         _ title: String = "",
         description: String = "",
         icon: Icon.Content,
+        value: String = "",
         disclosure: ListChoiceDisclosure = .disclosure(),
         showSeparator: Bool = true,
         action: @escaping () -> Void = {},
@@ -138,6 +151,7 @@ public extension ListChoice {
         self.title = title
         self.description = description
         self.icon = icon
+        self.value = value
         self.disclosure = disclosure
         self.showSeparator = showSeparator
         self.action = action
@@ -149,6 +163,7 @@ public extension ListChoice {
         _ title: String = "",
         description: String = "",
         icon: Icon.Symbol = .none,
+        value: String = "",
         disclosure: ListChoiceDisclosure = .disclosure(),
         showSeparator: Bool = true,
         action: @escaping () -> Void = {},
@@ -158,6 +173,7 @@ public extension ListChoice {
             title,
             description: description,
             icon: .icon(icon, size: .default, color: .inkNormal),
+            value: value,
             disclosure: disclosure,
             showSeparator: showSeparator,
             action: action,
@@ -170,6 +186,7 @@ public extension ListChoice {
         _ title: String = "",
         description: String = "",
         icon: Icon.Content,
+        value: String = "",
         disclosure: ListChoiceDisclosure = .disclosure(),
         showSeparator: Bool = true,
         action: @escaping () -> Void = {}
@@ -178,6 +195,7 @@ public extension ListChoice {
             title,
             description: description,
             icon: icon,
+            value: value,
             disclosure: disclosure,
             showSeparator: showSeparator,
             action: action,
@@ -190,6 +208,7 @@ public extension ListChoice {
         _ title: String = "",
         description: String = "",
         icon: Icon.Symbol = .none,
+        value: String = "",
         disclosure: ListChoiceDisclosure = .disclosure(),
         showSeparator: Bool = true,
         action: @escaping () -> Void = {}
@@ -198,6 +217,7 @@ public extension ListChoice {
             title,
             description: description,
             icon: .icon(icon, size: .default, color: .inkNormal),
+            value: value,
             disclosure: disclosure,
             showSeparator: showSeparator,
             action: action
@@ -248,6 +268,7 @@ struct ListChoicePreviews: PreviewProvider {
     
     static let title = "ListChoice tile"
     static let description = "Further description"
+    static let value = "value"
     static let addButton = ListChoiceDisclosure.button(type: .add)
     static let removeButton = ListChoiceDisclosure.button(type: .remove)
     static let uncheckedCheckbox = ListChoiceDisclosure.checkbox(isChecked: false)
@@ -261,6 +282,7 @@ struct ListChoicePreviews: PreviewProvider {
             ListChoice(title, icon: .airplane, disclosure: .none)
             ListChoice(title, icon: .icon(.airplane, size: .medium, color: .inkLighter), disclosure: .none)
             ListChoice(title, description: description, icon: .airplane, disclosure: .none)
+            ListChoice(title, description: description, icon: .airplane, value: value, disclosure: .none)
             ListChoice(title, description: description, disclosure: .none) {
                 customContentPlaceholder
             }
@@ -272,10 +294,17 @@ struct ListChoicePreviews: PreviewProvider {
     static var chevron: some View {
         VStack(spacing: .small) {
             ListChoice(title)
+            ListChoice(title, value: value)
             ListChoice(title, description: description)
+            ListChoice(title, description: description, value: value)
             ListChoice(title, icon: .airplane)
+            ListChoice(title, icon: .airplane, value: value)
             ListChoice(title, description: description, icon: .airplane)
+            ListChoice(title, description: description, icon: .airplane, value: value)
             ListChoice(title, description: description) {
+                customContentPlaceholder
+            }
+            ListChoice(title, description: description, value: value) {
                 customContentPlaceholder
             }
         }
@@ -293,6 +322,8 @@ struct ListChoicePreviews: PreviewProvider {
             ListChoice(title, icon: .airplane, disclosure: removeButton)
             ListChoice(title, description: description, icon: .airplane, disclosure: addButton)
             ListChoice(title, description: description, icon: .airplane, disclosure: removeButton)
+            ListChoice(title, description: description, icon: .airplane, value: value, disclosure: addButton)
+            ListChoice(title, description: description, icon: .airplane, value: value, disclosure: removeButton)
         }
         .padding()
         .previewDisplayName("Button")
@@ -308,6 +339,8 @@ struct ListChoicePreviews: PreviewProvider {
             ListChoice(title, icon: .airplane, disclosure: checkedCheckbox)
             ListChoice(title, description: description, icon: .airplane, disclosure: uncheckedCheckbox)
             ListChoice(title, description: description, icon: .airplane, disclosure: checkedCheckbox)
+            ListChoice(title, description: description, icon: .airplane, value: value, disclosure: uncheckedCheckbox)
+            ListChoice(title, description: description, icon: .airplane, value: value, disclosure: checkedCheckbox)
         }
         .padding()
         .previewDisplayName("Checkbox")

--- a/Sources/Orbit/Components/ListChoice.swift
+++ b/Sources/Orbit/Components/ListChoice.swift
@@ -1,6 +1,6 @@
 import SwiftUI
 
-public enum ListChoiceDisclosure {
+public enum ListChoiceDisclosure: Equatable {
     
     public enum ButtonType {
         case add
@@ -46,19 +46,12 @@ public struct ListChoice<Content: View>: View {
         .accessibility(hint: SwiftUI.Text(description))
     }
 
-    var buttonContent: some View {
-        HStack(spacing: 0) {
+    @ViewBuilder var buttonContent: some View {
+        HStack(spacing: .medium) {
             VStack(alignment: .leading, spacing: 0) {
-                HStack(spacing: .xSmall) {
-                    header
-                    Spacer(minLength: 0)
-                    Text(value)
-                        .padding(.trailing, valuePadding)
-                }
+                headerWithValue
                 content()
             }
-            
-            Strut(height: 48)
             
             disclosureView
                 .padding(.trailing, .medium)
@@ -67,7 +60,18 @@ public struct ListChoice<Content: View>: View {
         .overlay(separator, alignment: .bottom)
     }
     
-    var header: some View {
+    @ViewBuilder var headerWithValue: some View {
+        HStack(spacing: 0) {
+            header
+            Spacer(minLength: .xSmall)
+            Strut(height: 48)
+            Heading(value, style: .title4)
+        }
+        .padding(.leading, icon.isEmpty ? .medium : .small)
+        .padding(.trailing, disclosure == .none ? .medium : 0)
+    }
+    
+    @ViewBuilder var header: some View {
         Header(
             title,
             description: description,
@@ -77,9 +81,7 @@ public struct ListChoice<Content: View>: View {
             horizontalSpacing: .xSmall,
             verticalSpacing: .xxxSmall
         )
-        .padding(.vertical, headerTextPadding)
-        .padding(.leading, icon.isEmpty ? .medium : .small)
-        .padding(.trailing, .medium)
+        .padding(.vertical, .small)
     }
 
     @ViewBuilder var disclosureView: some View {
@@ -88,6 +90,7 @@ public struct ListChoice<Content: View>: View {
                 EmptyView()
             case .disclosure(let color):
                 Icon(symbol: .chevronRight, size: .medium, color: color)
+                    .padding(.leading, -.xSmall)
                     .padding(.trailing, -.xxSmall)
             case .button(let type):
                 disclosureButton(type: type)
@@ -115,22 +118,6 @@ public struct ListChoice<Content: View>: View {
 
     var separatorPadding: CGFloat {
         icon.isEmpty ? .medium : .xxLarge
-    }
-    
-    var isHeaderEmpty: Bool {
-        title.isEmpty && description.isEmpty && icon.isEmpty
-    }
-    
-    var headerTextPadding: CGFloat {
-        title.isEmpty || description.isEmpty ? .medium : .small
-    }
-    
-    var valuePadding: CGFloat {
-        if case .disclosure = disclosure {
-            return 0
-        } else {
-            return .xSmall
-        }
     }
 }
 
@@ -225,12 +212,6 @@ public extension ListChoice {
     }
 }
 
-// MARK: - Types
-public extension ListChoice {
-    
-    typealias BackgroundColor = (normal: Color, active: Color)
-}
-
 extension ListChoice {
     
     // Button style wrapper for ListChoice.
@@ -246,7 +227,7 @@ extension ListChoice {
         }
 
         func backgroundColor(isPressed: Bool) -> Color {
-            isPressed ? .inkLight.opacity(0.2) : .clear
+            isPressed ? .inkLight.opacity(0.08) : .clear
         }
     }
 }
@@ -256,13 +237,15 @@ struct ListChoicePreviews: PreviewProvider {
 
     static var previews: some View {
         PreviewWrapper {
+            standalone
             plain
             chevron
             button
             checkbox
             white
+            backgroundColor
         }
-        .background(Color.cloudLight.opacity(0.8))
+        .background(Color.cloudLight)
         .previewLayout(.sizeThatFits)
     }
     
@@ -274,8 +257,12 @@ struct ListChoicePreviews: PreviewProvider {
     static let uncheckedCheckbox = ListChoiceDisclosure.checkbox(isChecked: false)
     static let checkedCheckbox = ListChoiceDisclosure.checkbox(isChecked: true)
     
+    static var standalone: some View {
+        ListChoice(title, description: description, icon: .grid, value: "100")
+    }
+    
     static var plain: some View {
-        VStack(spacing: .small) {
+        ListChoiceGroup {
             ListChoice(title, disclosure: .none)
             ListChoice(title, description: description, disclosure: .none)
             ListChoice(title, description: "No Separator", disclosure: .none, showSeparator: false)
@@ -287,16 +274,15 @@ struct ListChoicePreviews: PreviewProvider {
                 customContentPlaceholder
             }
         }
-        .padding()
         .previewDisplayName("No disclosure")
     }
     
     static var chevron: some View {
-        VStack(spacing: .small) {
+        ListChoiceGroup {
             ListChoice(title)
-            ListChoice(title, value: value)
+            ListChoice(title, value: "10")
             ListChoice(title, description: description)
-            ListChoice(title, description: description, value: value)
+            ListChoice(title, description: "Multiline\ndescription", value: "USD")
             ListChoice(title, icon: .airplane)
             ListChoice(title, icon: .airplane, value: value)
             ListChoice(title, description: description, icon: .airplane)
@@ -304,16 +290,15 @@ struct ListChoicePreviews: PreviewProvider {
             ListChoice(title, description: description) {
                 customContentPlaceholder
             }
-            ListChoice(title, description: description, value: value) {
+            ListChoice(title, description: description, icon: .grid, value: value) {
                 customContentPlaceholder
             }
         }
-        .padding()
         .previewDisplayName("Chevron")
     }
     
     static var button: some View {
-        VStack(spacing: .small) {
+        ListChoiceGroup {
             ListChoice(title, disclosure: addButton)
             ListChoice(title, disclosure: removeButton)
             ListChoice(title, description: description, disclosure: addButton)
@@ -323,14 +308,15 @@ struct ListChoicePreviews: PreviewProvider {
             ListChoice(title, description: description, icon: .airplane, disclosure: addButton)
             ListChoice(title, description: description, icon: .airplane, disclosure: removeButton)
             ListChoice(title, description: description, icon: .airplane, value: value, disclosure: addButton)
-            ListChoice(title, description: description, icon: .airplane, value: value, disclosure: removeButton)
+            ListChoice(title, description: description, icon: .airplane, value: value, disclosure: removeButton) {
+                customContentPlaceholder
+            }
         }
-        .padding()
         .previewDisplayName("Button")
     }
 
     static var checkbox: some View {
-        VStack(spacing: .small) {
+        ListChoiceGroup {
             ListChoice(title, disclosure: uncheckedCheckbox)
             ListChoice(title, disclosure: checkedCheckbox)
             ListChoice(title, description: description, disclosure: uncheckedCheckbox)
@@ -340,9 +326,10 @@ struct ListChoicePreviews: PreviewProvider {
             ListChoice(title, description: description, icon: .airplane, disclosure: uncheckedCheckbox)
             ListChoice(title, description: description, icon: .airplane, disclosure: checkedCheckbox)
             ListChoice(title, description: description, icon: .airplane, value: value, disclosure: uncheckedCheckbox)
-            ListChoice(title, description: description, icon: .airplane, value: value, disclosure: checkedCheckbox)
+            ListChoice(title, description: description, icon: .airplane, value: value, disclosure: checkedCheckbox) {
+                customContentPlaceholder
+            }
         }
-        .padding()
         .previewDisplayName("Checkbox")
     }
     
@@ -367,5 +354,22 @@ struct ListChoicePreviews: PreviewProvider {
         }
         .padding()
         .previewDisplayName("White background")
+    }
+    
+    static var backgroundColor: some View {
+        VStack(spacing: .small) {
+            ListChoice(title, value: value, disclosure: .none) {
+                customContentPlaceholder
+            }
+            .background(Color.orangeLight)
+            
+            ListChoice(title, icon: .grid, value: value)
+            {
+                customContentPlaceholder
+            }
+            .background(Color.blueLight)
+        }
+        .padding()
+        .previewDisplayName("Custom background")
     }
 }


### PR DESCRIPTION
Adds `value` that we talked about. When looking at it again, I finally understood what you meant with the extra stacks. `value` works with all "disclosure"s and even without them. The position of the custom content should now be the same as before. Notably, `value` is centered - the first baseline does not look good next to the chevron, or anything else really.

<img width="375" alt="Screenshot 2022-02-04 at 22 31 46" src="https://user-images.githubusercontent.com/12349477/152606463-9227de96-66bc-4919-9376-2a36fb799e2b.png">
<img width="380" alt="Screenshot 2022-02-04 at 22 31 53" src="https://user-images.githubusercontent.com/12349477/152606469-7d5171b3-0b2c-4814-8946-b00ea69a6b92.png">
<img width="380" alt="Screenshot 2022-02-04 at 22 31 59" src="https://user-images.githubusercontent.com/12349477/152606473-a1df0d33-7544-495c-abc7-58a12a9aacc7.png">

