### PR TITLE
Add width option to adjust horizontal sizing for wrapper components.

### DIFF
--- a/Sources/Orbit/Components/ListChoice.swift
+++ b/Sources/Orbit/Components/ListChoice.swift
@@ -19,7 +19,7 @@ public enum ListChoiceDisclosure: Equatable {
 /// Shows one of a selectable list of items with similar structures.
 ///
 /// - Note: [Orbit definition](https://orbit.kiwi/components/listchoice/)
-/// - Important: Component expands horizontally to infinity up to a ``Layout/readableMaxWidth``.
+/// - Important: Component expands horizontally up to ``Layout/readableMaxWidth``.
 public struct ListChoice<Content: View>: View {
 
     let title: String
@@ -37,7 +37,14 @@ public struct ListChoice<Content: View>: View {
                 action()
             },
             label: {
-                buttonContent
+                HStack(spacing: .medium) {
+                    headerWithValue
+                    
+                    disclosureView
+                        .padding(.trailing, .medium)
+                }
+                .frame(maxWidth: Layout.readableMaxWidth, alignment: .leading)
+                .overlay(separator, alignment: .bottom)
             }
         )
         .buttonStyle(ListChoiceButtonStyle())
@@ -45,17 +52,6 @@ public struct ListChoice<Content: View>: View {
         .accessibility(hint: SwiftUI.Text(description))
         .accessibility(removeTraits: accessibilityTraitsToRemove)
         .accessibility(addTraits: accessibilityTraitsToAdd)
-    }
-
-    @ViewBuilder var buttonContent: some View {
-        HStack(spacing: .medium) {
-            headerWithValue
-            
-            disclosureView
-                .padding(.trailing, .medium)
-        }
-        .frame(maxWidth: Layout.readableMaxWidth, alignment: .leading)
-        .overlay(separator, alignment: .bottom)
     }
     
     @ViewBuilder var headerWithValue: some View {

--- a/Sources/Orbit/Components/ListChoiceGroup.swift
+++ b/Sources/Orbit/Components/ListChoiceGroup.swift
@@ -15,7 +15,7 @@ public enum ListChoiceGroupStyle {
 ///   - ``ListChoice``
 ///   - ``Card``
 ///
-/// - Important: Component expands horizontally to infinity up to a ``Layout/readableMaxWidth``.
+/// - Important: Expands horizontally up to ``Layout/readableMaxWidth`` by default and then centered. Can be adjusted by `width` property.
 public struct ListChoiceGroup<Content: View>: View {
 
     @Environment(\.horizontalSizeClass) var horizontalSizeClass
@@ -24,12 +24,21 @@ public struct ListChoiceGroup<Content: View>: View {
     let iconContent: Icon.Content
     let style: ListChoiceGroupStyle
     let titleStyle: Header.TitleStyle
+    let width: ContainerWidth
     let content: () -> Content
 
     public var body: some View {
         switch style {
             case .card(let status, let backgroundColor):
-                Card(title, spacing: 0, padding: 0, style: .iOS, status: status, backgroundColor: backgroundColor) {
+                Card(
+                    title,
+                    spacing: 0,
+                    padding: 0,
+                    style: .iOS,
+                    status: status,
+                    width: width,
+                    backgroundColor: backgroundColor
+                ) {
                     content()
                 }
             case .borderless:
@@ -48,7 +57,6 @@ public struct ListChoiceGroup<Content: View>: View {
         }
         .frame(maxWidth: Layout.readableMaxWidth, alignment: .leading)
         .frame(maxWidth: .infinity)
-        .padding(.horizontal, horizontalSizeClass == .regular ? .medium : 0)
     }
 }
 
@@ -61,12 +69,14 @@ public extension ListChoiceGroup {
         icon: Icon.Symbol = .none,
         style: ListChoiceGroupStyle = .card(),
         titleStyle: Header.TitleStyle = .title3,
+        width: ContainerWidth = .expanding(),
         @ViewBuilder content: @escaping () -> Content
     ) {
         self.title = title
         self.iconContent = .icon(icon, size: .header(titleStyle))
         self.style = style
         self.titleStyle = titleStyle
+        self.width = width
         self.content = content
     }
     
@@ -76,12 +86,14 @@ public extension ListChoiceGroup {
         iconContent: Icon.Content,
         style: ListChoiceGroupStyle = .card(),
         titleStyle: Header.TitleStyle = .title3,
+        width: ContainerWidth = .expanding(),
         @ViewBuilder content: @escaping () -> Content
     ) {
         self.title = title
         self.iconContent = iconContent
         self.style = style
         self.titleStyle = titleStyle
+        self.width = width
         self.content = content
     }
 }
@@ -130,7 +142,7 @@ struct ListChoiceGroupPreviews: PreviewProvider {
         listChoiceGroupsCard
             .background(Color.cloudLight)
             .environment(\.horizontalSizeClass, .regular)
-            .frame(width: Layout.readableMaxWidth - 200)
+            .frame(width: Layout.readableMaxWidth - 5)
             .previewDisplayName("Style - Card Regular narrow")
     }
     
@@ -152,7 +164,7 @@ struct ListChoiceGroupPreviews: PreviewProvider {
         listChoiceGroupsBorderless
             .background(Color.cloudLight)
             .environment(\.horizontalSizeClass, .regular)
-            .frame(width: Layout.readableMaxWidth - 200)
+            .frame(width: Layout.readableMaxWidth - 8)
             .previewDisplayName("Style - Borderless Regular narrow")
     }
 

--- a/Sources/Orbit/Components/TileGroup.swift
+++ b/Sources/Orbit/Components/TileGroup.swift
@@ -8,17 +8,25 @@ import SwiftUI
 ///   - ``ChoiceTile``
 ///
 /// - Note: [Orbit definition](https://orbit.kiwi/components/tilegroup/)
-/// - Important: Component expands horizontally to infinity up to a ``Layout/readableMaxWidth``.
+/// - Important: Expands horizontally up to ``Layout/readableMaxWidth`` by default and then centered. Can be adjusted by `width` property.
 public struct TileGroup<Content: View>: View {
 
     @Environment(\.horizontalSizeClass) var horizontalSizeClass
 
     let status: Status?
     let backgroundColor: Color?
+    let width: ContainerWidth
     let content: () -> Content
 
     public var body: some View {
-        Card(spacing: 0, padding: 0, style: .default, status: status, backgroundColor: backgroundColor) {
+        Card(
+            spacing: 0,
+            padding: 0,
+            style: .default,
+            status: status,
+            width: width,
+            backgroundColor: backgroundColor
+        ) {
             content()
         }
     }
@@ -34,10 +42,12 @@ public extension TileGroup {
     init(
         status: Status? = nil,
         backgroundColor: Color? = nil,
+        width: ContainerWidth = .expanding(),
         @ViewBuilder content: @escaping () -> Content
     ) {
         self.status = status
         self.backgroundColor = backgroundColor
+        self.width = width
         self.content = content
     }
 }

--- a/Sources/Orbit/Support/Layout/ContainerWidth.swift
+++ b/Sources/Orbit/Support/Layout/ContainerWidth.swift
@@ -1,0 +1,8 @@
+import CoreGraphics
+
+public enum ContainerWidth {
+    /// Expands horizontally up to `Layout.readableMaxWidth` by default.
+    /// Ensures enough padding when the size closely matches ``Layout/readableMaxWidth`` in regular size environment.
+    case expanding(upTo: CGFloat = Layout.readableMaxWidth, minimalRegularWidthPadding: CGFloat = .medium)
+    case intrinsic
+}


### PR DESCRIPTION
New intrinsic size option for Card:

![image](https://user-images.githubusercontent.com/35844477/154513196-4e17f06a-a0e3-4751-a151-ea71519b49ca.png)

Ability to nest containers (Card, ListChoiceGroup, TileGroup) with proper sizing in regular environment.

![image](https://user-images.githubusercontent.com/35844477/154513150-329eb6f4-469e-49d9-8fc6-7a3093e1afe2.png)
