### PR TITLE
Replace Illustration sizing with single enum option.

### DIFF
--- a/Sources/Orbit/Components/Dialog.swift
+++ b/Sources/Orbit/Components/Dialog.swift
@@ -15,7 +15,7 @@ public struct Dialog: View {
     public var body: some View {
         VStack(alignment: .center, spacing: .medium) {
             if let illustration = illustration {
-                Illustration(illustration, maxHeight: 120)
+                Illustration(illustration, size: .intrinsic(maxHeight: 120))
                     .padding(.top, .medium)
             }
 

--- a/Sources/Orbit/Components/EmptyState.swift
+++ b/Sources/Orbit/Components/EmptyState.swift
@@ -12,7 +12,7 @@ public struct EmptyState: View {
 
     public var body: some View {
         VStack(spacing: .medium) {
-            Illustration(illustration, maxHeight: 120)
+            Illustration(illustration, size: .intrinsic(maxHeight: 120))
                 .padding(.top, .large)
         
             texts

--- a/Sources/Orbit/Components/Icon.swift
+++ b/Sources/Orbit/Components/Icon.swift
@@ -57,7 +57,7 @@ public extension Icon {
                         .aspectRatio(contentMode: mode)
                         .frame(width: size.value, height: size.value)
                 case .illustration(let illlustration, let size):
-                    Illustration(illlustration, maxWidth: size.value, maxHeight: size.value, alignment: nil)
+                    Illustration(illlustration, size: .intrinsic(maxWidth: size.value, maxHeight: size.value))
                 case .none:
                     EmptyView()
             }


### PR DESCRIPTION
Added intrinsic sizing option

![image](https://user-images.githubusercontent.com/35844477/154532986-e37185b6-d85b-46fc-83f2-96d6ac231fa2.png)

Removed maxWidth option for alignment variant.

![image](https://user-images.githubusercontent.com/35844477/154533023-1630ded7-3db8-43e3-ae53-1ded07c01be3.png)
