### PR TITLE
Implement Secured InputField component

### DIFF
--- a/Sources/Orbit/Components/InputField.swift
+++ b/Sources/Orbit/Components/InputField.swift
@@ -90,15 +90,13 @@ public struct InputField: View {
             isEditing: $isEditing,
             style: .init(
                 textContentType: textContent,
-                autocapitalization: autocapitalization,
                 keyboardType: keyboard,
-                font: .orbit(size: Text.Size.normal.value, weight: .regular)
-            )
+                font: .orbit(size: Text.Size.normal.value, weight: .regular),
+                state: state
+            ),
+            onEditingChanged: onEditingChanged,
+            onCommit: onCommit
         )
-        .onTapGesture {
-            self.isEditing = true
-            onEditingChanged(isEditing)
-        }
         .background(textFieldPlaceholder, alignment: .leading)
     }
 
@@ -134,12 +132,14 @@ public struct InputField: View {
     }
 
     @ViewBuilder var securedSuffix: some View {
-        Icon(isSecureTextEntry ? .visibility : .visibilityOff, size: .default)
-            .padding(.horizontal, .xSmall)
-            .contentShape(Rectangle())
-            .onTapGesture {
-                isSecureTextEntry.toggle()
-            }
+        if value.isEmpty == false, state != .disabled {
+            Icon(isSecureTextEntry ? .visibility : .visibilityOff, size: .default)
+                .padding(.horizontal, .small)
+                .contentShape(Rectangle())
+                .onTapGesture {
+                    isSecureTextEntry.toggle()
+                }
+        }
     }
 }
 

--- a/Sources/Orbit/Components/InputField.swift
+++ b/Sources/Orbit/Components/InputField.swift
@@ -84,9 +84,19 @@ public struct InputField: View {
     }
 
     @ViewBuilder var secureField: some View {
-        SecureTextField(text: $value, isSecured: $isSecureTextEntry)
+        SecureTextField(
+            text: $value,
+            isSecured: $isSecureTextEntry,
+            isEditing: $isEditing,
+            style: .init(
+                textContentType: textContent,
+                autocapitalization: autocapitalization,
+                keyboardType: keyboard,
+                font: .orbit(size: Text.Size.normal.value, weight: .regular)
+            )
+        )
         .onTapGesture {
-            self.isEditing = isEditing
+            self.isEditing = true
             onEditingChanged(isEditing)
         }
         .background(textFieldPlaceholder, alignment: .leading)
@@ -124,14 +134,15 @@ public struct InputField: View {
     }
 
     @ViewBuilder var securedSuffix: some View {
-        Icon.Content.icon(isSecureTextEntry ? .visibility : .visibilityOff, size: .default)
-        .view()
-        .padding(.horizontal, .xSmall)
-        .onTapGesture {
-            isSecureTextEntry.toggle()
-        }
+        Icon(isSecureTextEntry ? .visibility : .visibilityOff, size: .default)
+            .padding(.horizontal, .xSmall)
+            .contentShape(Rectangle())
+            .onTapGesture {
+                isSecureTextEntry.toggle()
+            }
     }
 }
+
 
 // MARK: - Inits
 public extension InputField {
@@ -197,64 +208,15 @@ public extension InputField {
     }
 }
 
-private struct SecureTextField: UIViewRepresentable {
-    typealias UIViewType = UITextField
-
-    @Binding var text: String
-    @Binding var isSecured: Bool
-
-    func makeUIView(context: Context) -> UITextField {
-        let textFied = UITextField()
-        textFied.text = text
-        textFied.isSecureTextEntry = isSecured
-
-        textFied.delegate = context.coordinator
-
-        return textFied
-    }
-
-    func updateUIView(_ uiView: UITextField, context: Context) {
-        uiView.isSecureTextEntry = isSecured
-
-        if uiView.isSecureTextEntry, let text = uiView.text {
-            uiView.text?.removeAll()
-            uiView.insertText(text)
-        }
-    }
-
-    func makeCoordinator() -> Coordinator {
-        Coordinator($text)
-    }
-
-    class Coordinator: NSObject, UITextFieldDelegate {
-        var text: Binding<String>
-
-        init(_ text: Binding<String>) {
-            self.text = text
-        }
-
-        public func textFieldDidEndEditing(_ textField: UITextField) {
-            self.text.wrappedValue = textField.text ?? ""
-        }
-
-        public func textFieldShouldReturn(_ textField: UITextField) -> Bool {
-            self.text.wrappedValue = textField.text ?? ""
-            return true
-        }
-    }
-}
-
 // MARK: - Previews
 struct InputFieldPreviews: PreviewProvider {
 
     static var previews: some View {
-        Group {
-            PreviewWrapper {
-                standalone
-                snapshots
-            }
-            .previewLayout(PreviewLayout.sizeThatFits)
+        PreviewWrapper {
+            standalone
+            snapshots
         }
+        .previewLayout(PreviewLayout.sizeThatFits)
     }
 
     static var standalone: some View {
@@ -296,7 +258,7 @@ struct InputFieldLivePreviews: PreviewProvider {
         PreviewWrapper()
         securedWrapper
     }
-
+    
     struct PreviewWrapper: View {
 
         @State var message: MessageType = .none

--- a/Sources/Orbit/Components/InputField.swift
+++ b/Sources/Orbit/Components/InputField.swift
@@ -43,26 +43,24 @@ public struct InputField: View {
                 state: state,
                 message: message,
                 isEditing: isEditing,
-                suffixAction: suffixAction,
-                label: {
-                    HStack(spacing: 0) {
-                        input
-                            .textFieldStyle(TextFieldStyle(leadingPadding: 0))
-                            .autocapitalization(autocapitalization)
-                            .disableAutocorrection(isAutocompleteEnabled == false)
-                            .textContentType(textContent)
-                            .keyboardType(keyboard)
-                            .font(.orbit(size: Text.Size.normal.value, weight: .regular))
-                            .accentColor(.blueNormal)
-                            .frame(height: Layout.preferredButtonHeight)
-                            .background(textFieldPlaceholder, alignment: .leading)
-                            .disabled(state == .disabled)
-                        if isSecure {
-                            securedSuffix
-                        } else {
-                            Spacer(minLength: 0)
-                            clearButton
-                        }
+                suffixAction: suffixAction
+            ) {
+                HStack(spacing: 0) {
+                    input
+                        .textFieldStyle(TextFieldStyle(leadingPadding: 0))
+                        .autocapitalization(autocapitalization)
+                        .disableAutocorrection(isAutocompleteEnabled == false)
+                        .textContentType(textContent)
+                        .keyboardType(keyboard)
+                        .font(.orbit(size: Text.Size.normal.value, weight: .regular))
+                        .accentColor(.blueNormal)
+                        .frame(height: Layout.preferredButtonHeight)
+                        .background(textFieldPlaceholder, alignment: .leading)
+                        .disabled(state == .disabled)
+                    if isSecure {
+                        securedSuffix
+                    } else {
+                        clearButton
                     }
                 }
             }
@@ -133,7 +131,7 @@ public struct InputField: View {
 
     @ViewBuilder var securedSuffix: some View {
         if value.isEmpty == false, state != .disabled {
-            Icon(isSecureTextEntry ? .visibility : .visibilityOff, size: .default)
+            Icon(isSecureTextEntry ? .visibility : .visibilityOff, size: .normal)
                 .padding(.horizontal, .small)
                 .contentShape(Rectangle())
                 .onTapGesture {
@@ -230,16 +228,15 @@ struct InputFieldPreviews: PreviewProvider {
         InputField("Disabled, Empty", value: .constant(""), placeholder: "Placeholder", state: .disabled)
         InputField("Disabled", value: .constant("Disabled Value"), placeholder: "Placeholder", state: .disabled)
         InputField("Default", value: .constant("InputField Value"))
-        InputField("Secured", value: .constant("password"), isSecure: true)
         InputField("Modified", value: .constant("Modified value"), state: .modified)
         InputField("Focused", value: .constant("Focus / Help"), message: .help("Help message"))
+        InputField("Secured", value: .constant("password"), isSecure: true)
         InputField(
             "InputField with a long multiline label to test that it works",
             value: .constant("Error value with a very long length to test that it works"),
             message: .error("Error message, also very long and multi-line to test that it works.")
         )
         InputField(value: .constant("InputField with no label"))
-        standalone
         InputField(value: .constant("InputField with CountryFlag prefix"), prefix: .countryFlag("us"))
     }
 

--- a/Sources/Orbit/Support/Forms/InputStyle.swift
+++ b/Sources/Orbit/Support/Forms/InputStyle.swift
@@ -19,6 +19,21 @@ public enum InputState {
             case .default, .modified:   return .inkLighter
         }
     }
+
+    public var textUIColor: UIColor {
+        switch self {
+            case .disabled:         return .cloudDarkerActive
+            case .default:          return .inkNormal
+            case .modified:         return .blueDark
+        }
+    }
+
+    public var placeholderUIColor: UIColor {
+        switch self {
+            case .disabled:             return textUIColor
+            case .default, .modified:   return .inkLighter
+        }
+    }
 }
 
 /// Content for inputs that share common layout with a prefix and suffix.

--- a/Sources/Orbit/Support/Views/SecureTextField.swift
+++ b/Sources/Orbit/Support/Views/SecureTextField.swift
@@ -2,6 +2,7 @@ import SwiftUI
 import UIKit
 
 struct SecureTextFieldStyle {
+    // FIXME: support autocapitalization to match InputField style
     let textContentType: UITextContentType?
     let keyboardType: UIKeyboardType
     let font: UIFont

--- a/Sources/Orbit/Support/Views/SecureTextField.swift
+++ b/Sources/Orbit/Support/Views/SecureTextField.swift
@@ -48,8 +48,10 @@ struct SecureTextField: UIViewRepresentable {
             return
         }
 
-        if uiView.isSecureTextEntry && uiView.text == text {
-            // Workaround. Without it, UITextField will erase it's own current value on frist input
+        // Workaround. Without it, UITextField will erase it's own current value on frist input
+        let didUserJustDidStartEditing = uiView.isSecureTextEntry && uiView.text == text
+        let isTextModifiedOutsideTextField = text != context.coordinator.textFieldInput
+        if didUserJustDidStartEditing || isTextModifiedOutsideTextField {
             uiView.text?.removeAll()
             uiView.insertText(text)
         }
@@ -64,6 +66,8 @@ struct SecureTextField: UIViewRepresentable {
         var isEditing: Binding<Bool>
         let onEditingChanged: (Bool) -> Void
         let onCommit: () -> Void
+
+        private(set) lazy var textFieldInput: String = text.wrappedValue
 
         init(text: Binding<String>,
              isEditing: Binding<Bool>,
@@ -87,6 +91,7 @@ struct SecureTextField: UIViewRepresentable {
             }
 
             text.wrappedValue = textField.text ?? ""
+            textFieldInput = text.wrappedValue
             onCommit()
 
             isEditing.wrappedValue = false
@@ -105,9 +110,11 @@ struct SecureTextField: UIViewRepresentable {
                 specialRange.clamped(to: text.wrappedValue.startIndex..<text.wrappedValue.endIndex) == specialRange {
 
                 text.wrappedValue.replaceSubrange(specialRange, with: string)
+                textFieldInput = text.wrappedValue
             } else {
                 assertionFailure("Unexpected flow. Please report an issue.")
             }
+
             return true
         }
     }

--- a/Sources/Orbit/Support/Views/SecureTextField.swift
+++ b/Sources/Orbit/Support/Views/SecureTextField.swift
@@ -1,0 +1,87 @@
+import SwiftUI
+import UIKit
+
+struct SecureTextFieldStyle {
+    let textContentType: UITextContentType?
+    let autocapitalization: UITextAutocapitalizationType
+    let keyboardType: UIKeyboardType
+    let font: UIFont
+    let state: InputState = .default
+}
+
+struct SecureTextField: UIViewRepresentable {
+    typealias UIViewType = UITextField
+
+    @Binding var text: String
+    @Binding var isSecured: Bool
+    @Binding var isEditing: Bool
+    let style: SecureTextFieldStyle
+
+    func makeUIView(context: Context) -> UITextField {
+        let textFied = UITextField()
+        textFied.autocorrectionType = .no
+        textFied.delegate = context.coordinator
+
+        textFied.text = text
+        textFied.isSecureTextEntry = isSecured
+        textFied.textContentType = style.textContentType
+        textFied.autocapitalizationType = style.autocapitalization
+        textFied.keyboardType = style.keyboardType
+        textFied.font = style.font
+        textFied.textColor = style.state.textUIColor
+        textFied.clearsOnBeginEditing = false
+
+        if isEditing && textFied.canBecomeFirstResponder {
+            textFied.becomeFirstResponder()
+        }
+
+        return textFied
+    }
+
+    func updateUIView(_ uiView: UITextField, context: Context) {
+        uiView.isSecureTextEntry = isSecured
+
+        if uiView.isSecureTextEntry && uiView.text == text {
+            // Workaround. Without it, UITextField will erase it's own current value on frist input
+            uiView.text?.removeAll()
+            uiView.insertText(text)
+        }
+    }
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(text: $text, isEditing: $isEditing)
+    }
+
+    class Coordinator: NSObject, UITextFieldDelegate {
+        var text: Binding<String>
+        var isEditing: Binding<Bool>
+
+        init(text: Binding<String>, isEditing: Binding<Bool>) {
+            self.text = text
+            self.isEditing = isEditing
+        }
+
+        public func textFieldDidEndEditing(_ textField: UITextField) {
+            endEditing(textField)
+        }
+
+        public func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+            endEditing(textField)
+            return true
+        }
+
+        func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
+
+            if let input = textField.text, let specialRange = Range(range, in: input) {
+                text.wrappedValue.replaceSubrange(specialRange, with: string)
+            }
+            return true
+        }
+
+        private func endEditing(_ textField: UITextField) {
+            textField.resignFirstResponder()
+            text.wrappedValue = textField.text ?? ""
+            isEditing.wrappedValue = false
+        }
+    }
+}


### PR DESCRIPTION

min iOS version is bumped to v14 to use `onChange(of:perform:)` 

I've added SecuredField as an option of InputField, but maybe it should be a completely separate component? 