### PR TITLE
Choice tile states

### DIFF
--- a/Sources/Orbit/Components/ChoiceTile.swift
+++ b/Sources/Orbit/Components/ChoiceTile.swift
@@ -26,19 +26,14 @@ public struct ChoiceTileButtonStyle: SwiftUI.ButtonStyle {
 
     let indicator: ChoiceTileIndicator
     let alignment: ChoiceTileAlignment
-    let status: Status?
+    let isError: Bool
     let isSelected: Bool
 
     /// Creates button style wrapper for ``ChoiceTile``.
-    public init(
-        indicator: ChoiceTileIndicator,
-        alignment: ChoiceTileAlignment,
-        status: Status?,
-        isSelected: Bool
-    ) {
+    public init(indicator: ChoiceTileIndicator, alignment: ChoiceTileAlignment, isError: Bool, isSelected: Bool) {
         self.indicator = indicator
         self.alignment = alignment
-        self.status = status
+        self.isError = isError
         self.isSelected = isSelected
     }
 
@@ -48,7 +43,6 @@ public struct ChoiceTileButtonStyle: SwiftUI.ButtonStyle {
             .padding(ChoiceTileAlignment.padding)
             .tileBorder(
                 isSelected: isSelected,
-                status: status,
                 backgroundColor: backgroundColor(isPressed: configuration.isPressed),
                 shadow: shadow(isPressed: configuration.isPressed))
     }
@@ -62,8 +56,8 @@ public struct ChoiceTileButtonStyle: SwiftUI.ButtonStyle {
     @ViewBuilder var indicatorElement: some View {
         switch indicator {
             case .none:         EmptyView()
-            case .radio:        Radio(state: status == .critical ? .error : .normal, isChecked: isSelected)
-            case .checkbox:     Checkbox(state: status == .critical ? .error : .normal, isChecked: isSelected)
+            case .radio:        Radio(state: isError ? .error : .normal, isChecked: isSelected)
+            case .checkbox:     Checkbox(state: isError ? .error : .normal, isChecked: isSelected)
         }
     }
     
@@ -79,7 +73,7 @@ public struct ChoiceTileButtonStyle: SwiftUI.ButtonStyle {
     }
     
     func shadow(isPressed: Bool) -> TileBorderModifier.Shadow {
-        if status != nil {
+        if isError {
             return .none
         }
         
@@ -110,7 +104,7 @@ public struct ChoiceTile<Content: View>: View {
     let indicator: ChoiceTileIndicator
     let titleStyle: Header.TitleStyle
     let isSelected: Bool
-    let status: Status?
+    let isError: Bool
     let message: MessageType
     let alignment: ChoiceTileAlignment
     let action: () -> Void
@@ -132,7 +126,7 @@ public struct ChoiceTile<Content: View>: View {
                 .padding(.top, badgeOverlay.isEmpty ? 0 : .small)
             }
         )
-        .buttonStyle(ChoiceTileButtonStyle(indicator: indicator, alignment: alignment, status: status, isSelected: isSelected))
+        .buttonStyle(ChoiceTileButtonStyle(indicator: indicator, alignment: alignment, isError: isError, isSelected: isSelected))
         .accessibility(removeTraits: isSelected == false ? .isSelected : [])
         .accessibility(addTraits: isSelected ? .isSelected : [])
         .overlay(badgeOverlayView, alignment: .top)
@@ -223,7 +217,7 @@ public extension ChoiceTile {
         indicator: ChoiceTileIndicator = .radio,
         titleStyle: Header.TitleStyle = .title3,
         isSelected: Bool = false,
-        status: Status? = nil,
+        isError: Bool = false,
         message: MessageType = .none,
         alignment: ChoiceTileAlignment = .default,
         action: @escaping () -> Void = {},
@@ -237,7 +231,7 @@ public extension ChoiceTile {
         self.indicator = indicator
         self.titleStyle = titleStyle
         self.isSelected = isSelected
-        self.status = status
+        self.isError = isError
         self.message = message
         self.alignment = alignment
         self.action = action
@@ -254,7 +248,7 @@ public extension ChoiceTile {
         indicator: ChoiceTileIndicator = .radio,
         titleStyle: Header.TitleStyle = .title3,
         isSelected: Bool = false,
-        status: Status? = nil,
+        isError: Bool = false,
         message: MessageType = .none,
         alignment: ChoiceTileAlignment = .default,
         action: @escaping () -> Void = {},
@@ -269,7 +263,7 @@ public extension ChoiceTile {
             indicator: indicator,
             titleStyle: titleStyle,
             isSelected: isSelected,
-            status: status,
+            isError: isError,
             message: message,
             alignment: alignment,
             action: action,
@@ -409,7 +403,7 @@ struct ChoiceTilePreviews: PreviewProvider {
                 VStack(alignment: .leading, spacing: .medium) {
                     ChoiceTile("Label", description: "Unchecked Radio", icon: .grid, message: .help("Helpful message")) {}
 
-                    ChoiceTile("Label", indicator: .checkbox, status: .critical) {
+                    ChoiceTile("Label", indicator: .checkbox, isError: true) {
                         customContentPlaceholder
                     }
                 }
@@ -417,7 +411,7 @@ struct ChoiceTilePreviews: PreviewProvider {
                 VStack(alignment: .leading, spacing: .medium) {
                     ChoiceTile("Label", description: "Checked Checkbox", isSelected: true, message: .help("Helpful message")) {}
 
-                    ChoiceTile("Label", description: "Checked Checkbox", indicator: .checkbox, isSelected: true, status: .critical, message: .error("Error message")) {}
+                    ChoiceTile("Label", description: "Checked Checkbox", indicator: .checkbox, isSelected: true, isError: true, message: .error("Error message")) {}
                 }
             }
 
@@ -436,7 +430,7 @@ struct ChoiceTilePreviews: PreviewProvider {
                 customContentPlaceholder
             }
             
-            ChoiceTile(indicator: .checkbox, isSelected: true, status: .critical) {
+            ChoiceTile(indicator: .checkbox, isSelected: true, isError: true) {
                 customContentPlaceholder
             }
             
@@ -459,7 +453,7 @@ struct ChoiceTilePreviews: PreviewProvider {
                 VStack(alignment: .leading, spacing: .medium) {
                     ChoiceTile("Label", description: "Unchecked Radio", isSelected: true, message: .help("Helpful message"), alignment: .center) {}
 
-                    ChoiceTile("Label", description: "Checked Checkbox", indicator: .checkbox, isSelected: true, status: .critical, message: .error("Error message"), alignment: .center) {}
+                    ChoiceTile("Label", description: "Checked Checkbox", indicator: .checkbox, isSelected: true, isError: true, message: .error("Error message"), alignment: .center) {}
                 }
             }
 

--- a/Sources/Orbit/Components/ListChoice.swift
+++ b/Sources/Orbit/Components/ListChoice.swift
@@ -13,7 +13,7 @@ public enum ListChoiceDisclosure: Equatable {
     /// A non-interactive button.
     case button(type: ButtonType)
     /// A non-interactive checkbox.
-    case checkbox(isChecked: Bool = true)
+    case checkbox(isChecked: Bool = true, state: Checkbox.State = .normal)
 }
 
 /// Shows one of a selectable list of items with similar structures.
@@ -91,8 +91,8 @@ public struct ListChoice<Content: View>: View {
                 disclosureButton(type: type)
                     .padding(.vertical, .small)
                     .disabled(true)
-            case .checkbox(let isChecked):
-                Checkbox(isChecked: isChecked)
+            case .checkbox(let isChecked, let state):
+                Checkbox(state: state, isChecked: isChecked)
                     .disabled(true)
         }
     }
@@ -129,15 +129,15 @@ public struct ListChoice<Content: View>: View {
     
     var accessibilityTraitsToAdd: AccessibilityTraits {
         switch disclosure {
-            case .none, .disclosure, .button, .checkbox(false):     return []
-            case .checkbox(true):                                   return .isSelected
+            case .none, .disclosure, .button, .checkbox(false, _):     return []
+            case .checkbox(true, _):                                   return .isSelected
         }
     }
     
     var accessibilityTraitsToRemove: AccessibilityTraits {
         switch disclosure {
-            case .none, .disclosure, .button, .checkbox(true):      return []
-            case .checkbox(false):                                  return .isSelected
+            case .none, .disclosure, .button, .checkbox(true, _):      return []
+            case .checkbox(false, _):                                  return .isSelected
         }
     }
 }
@@ -376,10 +376,10 @@ struct ListChoicePreviews: PreviewProvider {
         ListChoiceGroup {
             ListChoice(title, disclosure: uncheckedCheckbox)
             ListChoice(title, disclosure: checkedCheckbox)
-            ListChoice(title, description: description, disclosure: uncheckedCheckbox)
-            ListChoice(title, description: description, disclosure: checkedCheckbox)
-            ListChoice(title, icon: .airplane, disclosure: uncheckedCheckbox)
-            ListChoice(title, icon: .airplane, disclosure: checkedCheckbox)
+            ListChoice(title, description: description, disclosure: .checkbox(state: .error))
+            ListChoice(title, description: description, disclosure: .checkbox(state: .disabled))
+            ListChoice(title, icon: .airplane, disclosure: .checkbox(isChecked: false, state: .error))
+            ListChoice(title, icon: .airplane, disclosure: .checkbox(isChecked: false, state: .disabled))
             ListChoice(title, description: description, icon: .airplane, disclosure: uncheckedCheckbox)
             ListChoice(title, description: description, icon: .airplane, disclosure: checkedCheckbox)
             ListChoice(title, description: description, icon: .airplane, value: value, disclosure: uncheckedCheckbox)


### PR DESCRIPTION
Design update - error in ChoiceTile should be only visible on indicator, not on border.

<img width="340" alt="image" src="https://user-images.githubusercontent.com/35844477/158457367-ba85a755-654d-4d6b-8db0-410b3b7fda15.png">
