### PR TITLE
Update icon sizes

### DIFF
--- a/Sources/Orbit/Components/Alert.swift
+++ b/Sources/Orbit/Components/Alert.swift
@@ -47,7 +47,7 @@ public struct Alert<Content: View>: View {
             Label(
                 title,
                 description: description,
-                iconContent: .icon(icon, size: .default, color: status.color),
+                iconContent: .icon(icon, color: status.color),
                 titleStyle: .text(weight: .bold),
                 descriptionStyle: .custom(.normal, color: .inkNormal, linkColor: .inkNormal),
                 descriptionLinkAction: descriptionLinkAction

--- a/Sources/Orbit/Components/Badge.swift
+++ b/Sources/Orbit/Components/Badge.swift
@@ -272,6 +272,11 @@ struct BadgePreviews: PreviewProvider {
                         backgroundColor: .white
                     )
                 )
+                
+                Badge(
+                    "Flag",
+                    iconContent: .countryFlag("us")
+                )
             }
             .padding(.vertical)
             .previewDisplayName("Custom")

--- a/Sources/Orbit/Components/Badge.swift
+++ b/Sources/Orbit/Components/Badge.swift
@@ -22,18 +22,16 @@ public struct Badge: View {
     public var body: some View {
         if isEmpty == false {
             HStack(spacing: size.spacing) {
-                iconContent.view()
+                Icon(iconContent)
                 
-                if label.isEmpty == false {
-                    Text(
-                        label,
-                        size: .small,
-                        color: .custom(style.labelColor),
-                        weight: .medium,
-                        linkColor: style.labelColor
-                    )
-                    .lineLimit(1)
-                }
+                Text(
+                    label,
+                    size: .small,
+                    color: .custom(style.labelColor),
+                    weight: .medium,
+                    linkColor: style.labelColor
+                )
+                .lineLimit(1)
             }
             .padding(.horizontal, size.padding)
             .frame(minWidth: size.height)

--- a/Sources/Orbit/Components/BadgeList.swift
+++ b/Sources/Orbit/Components/BadgeList.swift
@@ -22,7 +22,7 @@ public struct BadgeList: View {
     public var body: some View {
         HStack(alignment: .firstTextBaseline, spacing: Self.spacing) {
             badgeBackground
-                .overlay(iconContent.view())
+                .overlay(Icon(iconContent))
                 .alignmentGuide(.firstTextBaseline) { size in
                     Text.Size.small.value * Text.firstBaselineRatio + size.height / 2
                 }

--- a/Sources/Orbit/Components/Button.swift
+++ b/Sources/Orbit/Components/Button.swift
@@ -113,7 +113,7 @@ public extension Button {
         disclosureIcon: Icon.Symbol = .none,
         action: @escaping () -> Void = {}
     ) {
-        let iconSize: Icon.Size = size == .small ? .small : .medium
+        let iconSize: Icon.Size = size == .small ? .small : .large
         self.init(
             label,
             style: style,
@@ -393,7 +393,7 @@ struct ButtonPreviews: PreviewProvider {
             Button(
                 "Custom",
                 style: .critical,
-                iconContent: .icon(.check, size: .large, color: .blueNormal)
+                iconContent: .icon(.check, size: .xLarge, color: .blueNormal)
             )
             .padding(.vertical)
             .previewDisplayName("Custom")

--- a/Sources/Orbit/Components/Button.swift
+++ b/Sources/Orbit/Components/Button.swift
@@ -30,7 +30,7 @@ public struct Button: View {
                         Spacer(minLength: 0)
                     }
 
-                    iconContent.view()
+                    Icon(iconContent)
 
                     if #available(iOS 14.0, *) {
                         Text(
@@ -54,9 +54,7 @@ public struct Button: View {
 
                     Spacer(minLength: 0)
 
-                    if disclosureIconContent.isEmpty == false {
-                        disclosureIconContent.view()
-                    }
+                    Icon(disclosureIconContent)
                 }
                 .padding(.horizontal, label.isEmpty ? 0 : size.padding)
             }

--- a/Sources/Orbit/Components/ButtonLink.swift
+++ b/Sources/Orbit/Components/ButtonLink.swift
@@ -72,7 +72,7 @@ public extension ButtonLink {
         self.init(
             label,
             style: style,
-            iconContent: .icon(icon, size: .small),
+            iconContent: .icon(icon),
             size: size,
             action: action
         )

--- a/Sources/Orbit/Components/ButtonLink.swift
+++ b/Sources/Orbit/Components/ButtonLink.swift
@@ -253,6 +253,10 @@ struct ButtonLinkPreviews: PreviewProvider {
                 .background(Color.blueLight)
                 .padding(.vertical)
                 .previewDisplayName("Icon only")
+            
+            ButtonLink("Flag", iconContent: .countryFlag("us"))
+                .padding(.vertical)
+                .previewDisplayName("Country flag")
         }
         .padding(.horizontal)
     }

--- a/Sources/Orbit/Components/ButtonLink.swift
+++ b/Sources/Orbit/Components/ButtonLink.swift
@@ -26,7 +26,7 @@ public struct ButtonLink: View {
             },
             label: {
                 HStack(spacing: .xSmall) {
-                    iconContent.view()
+                    Icon(iconContent)
                     
                     Text(
                         label,

--- a/Sources/Orbit/Components/Card.swift
+++ b/Sources/Orbit/Components/Card.swift
@@ -218,7 +218,7 @@ public extension Card {
     ) {
         self.title = title
         self.description = description
-        self.iconContent = .icon(icon, size: .header(titleStyle))
+        self.iconContent = .icon(icon, size: .label(titleStyle))
         self.alignment = alignment
         self.action = action
         self.headerSpacing = headerSpacing

--- a/Sources/Orbit/Components/Card.swift
+++ b/Sources/Orbit/Components/Card.swift
@@ -460,7 +460,7 @@ struct CardPreviews: PreviewProvider {
         ) {
             VStack(spacing: 0) {
                 ListChoice("ListChoice")
-                ListChoice("ListChoice", icon: .notification)
+                ListChoice("ListChoice", icon: .countryFlag("us"))
                 ListChoice("ListChoice", description: "ListChoice description", icon: .airplane)
             }
             .padding(.top, .xSmall)

--- a/Sources/Orbit/Components/CarrierLogo.swift
+++ b/Sources/Orbit/Components/CarrierLogo.swift
@@ -12,20 +12,6 @@ import SwiftUI
 /// - Note: [Orbit definition](https://orbit.kiwi/components/visuals/carrierlogo/)
 public struct CarrierLogo: View {
     
-    public enum Size {
-        case small
-        case medium
-        case large
-        
-        var value: Double {
-            switch self {
-                case .small:    return 16
-                case .medium:   return 24
-                case .large:    return 32
-            }
-        }
-    }
-    
     struct SingleCarrierImage: View {
         
         let image: Image
@@ -42,7 +28,7 @@ public struct CarrierLogo: View {
     }
     
     let images: [Image]
-    let size: Size
+    let size: Icon.Size
     
     public var body: some View {
         content
@@ -102,7 +88,7 @@ public struct CarrierLogo: View {
     /// - Parameters:
     ///   - image: a logo image.
     ///   - size: the size of the view. The image will occupy the whole view.
-    public init(image: Image, size: Size) {
+    public init(image: Image, size: Icon.Size) {
         self.images = [image]
         self.size = size
     }
@@ -123,7 +109,7 @@ struct CarrierLogoPreviews: PreviewProvider {
         Group {
             HStack {
                 CarrierLogo(image: square, size: .small)
-                CarrierLogo(image: square, size: .medium)
+                CarrierLogo(image: square, size: .normal)
                 CarrierLogo(image: square, size: .large)
             }
             .padding()

--- a/Sources/Orbit/Components/ChoiceTile.swift
+++ b/Sources/Orbit/Components/ChoiceTile.swift
@@ -401,7 +401,7 @@ struct ChoiceTilePreviews: PreviewProvider {
         VStack(spacing: .large) {
             HStack(alignment: .top, spacing: .medium) {
                 VStack(alignment: .leading, spacing: .medium) {
-                    ChoiceTile("Label", description: "Unchecked Radio", icon: .grid, message: .help("Helpful message")) {}
+                    ChoiceTile("Label", description: "Unchecked Radio", iconContent: .countryFlag("cz", size: .large), message: .help("Helpful message")) {}
 
                     ChoiceTile("Label", indicator: .checkbox, isError: true) {
                         customContentPlaceholder
@@ -445,7 +445,7 @@ struct ChoiceTilePreviews: PreviewProvider {
         VStack(spacing: .large) {
             HStack(alignment: .top, spacing: .medium) {
                 VStack(alignment: .leading, spacing: .medium) {
-                    ChoiceTile("Label", description: "Checked Radio", icon: .flightNomad, message: .help("Helpful message"), alignment: .center) {}
+                    ChoiceTile("Label", description: "Checked Radio", iconContent: .countryFlag("cz", size: .large), message: .help("Helpful message"), alignment: .center) {}
 
                     ChoiceTile("Label", description: "Unchecked Checkbox", indicator: .checkbox, message: .help("Helpful message"), alignment: .center) {}
                 }

--- a/Sources/Orbit/Components/ChoiceTile.swift
+++ b/Sources/Orbit/Components/ChoiceTile.swift
@@ -257,7 +257,7 @@ public extension ChoiceTile {
         self.init(
             title,
             description: description,
-            iconContent: .icon(icon, size: .header(titleStyle)),
+            iconContent: .icon(icon, size: .label(titleStyle)),
             badge: badge,
             badgeOverlay: badgeOverlay,
             indicator: indicator,

--- a/Sources/Orbit/Components/ChoiceTile.swift
+++ b/Sources/Orbit/Components/ChoiceTile.swift
@@ -143,7 +143,7 @@ public struct ChoiceTile<Content: View>: View {
                     }
                 case .center:
                     VStack(spacing: .xxSmall) {
-                        iconContent.view()
+                        Icon(iconContent)
                             .padding(.bottom, .xxxSmall)
                         centeredHeading
                         Text(description, color: .inkLight, alignment: .center)

--- a/Sources/Orbit/Components/CountryFlag.swift
+++ b/Sources/Orbit/Components/CountryFlag.swift
@@ -7,24 +7,32 @@ import SwiftUI
 ///
 /// - Note: [Orbit definition](https://orbit.kiwi/components/countryflag/)
 public struct CountryFlag: View {
-
+    
     let countryCode: String
-    let height: Height
+    let size: Icon.Size
     let border: Border
 
     public var body: some View {
         SwiftUI.Image(countryCode.lowercased(), bundle: .current)
             .resizable()
             .scaledToFit()
-            .frame(height: height.value)
             .clipShape(clipShape)
             .overlay(
-                clipShape.stroke(border.color, lineWidth: BorderWidth.thin)
+                clipShape.strokeBorder(border.color, lineWidth: BorderWidth.hairline)
+                    .blendMode(.darken)
             )
+            .padding(Icon.averagePadding)
+            .frame(width: size.value)
+            .fixedSize()
     }
 
-    @ViewBuilder var clipShape: some Shape {
-        RoundedRectangle(cornerRadius: height.value / 8)
+    var clipShape: some InsettableShape {
+        switch border {
+            case .none:
+                return RoundedRectangle(cornerRadius: 0)
+            case .default:
+                return RoundedRectangle(cornerRadius: size.value / 10)
+        }
     }
 }
 
@@ -32,38 +40,15 @@ public struct CountryFlag: View {
 public extension CountryFlag {
 
     /// Creates Orbit CountryFlag component.
-    init(_ countryCode: String, height: Height = .default, border: Border = .default) {
+    init(_ countryCode: String, size: Icon.Size = .normal, border: Border = .default) {
         self.countryCode = countryCode
-        self.height = height
+        self.size = size
         self.border = border
     }
 }
 
 // MARK: - Types
 public extension CountryFlag {
-
-    enum Height: Equatable {
-        /// 12 pts CountryFlag height.
-        case small
-        /// 16 pts CountryFlag height.
-        case `default`
-        /// 20 pts CountryFlag height.
-        case medium
-        /// 24pts CountryFlag height.
-        case large
-        /// Custom CountryFlag height.
-        case custom(CGFloat)
-
-        public var value: CGFloat {
-            switch self {
-                case .small:                return 12
-                case .default:              return 16
-                case .medium:               return 20
-                case .large:                return 24
-                case .custom(let size):     return size
-            }
-        }
-    }
 
     enum Border {
         case none
@@ -72,7 +57,7 @@ public extension CountryFlag {
         var color: Color {
             switch self {
                 case .none:                 return .clear
-                case .default:              return .cloudDark
+                case .default:              return .cloudDarker.opacity(0.8)
             }
         }
     }
@@ -84,8 +69,13 @@ struct CountryFlagPreviews: PreviewProvider {
     static var previews: some View {
         PreviewWrapper {
             CountryFlag("cz")
-            CountryFlag("us", height: .small)
-            CountryFlag("unknown", height: .large)
+            CountryFlag("cz", border: .none)
+            CountryFlag("sg")
+            CountryFlag("jp")
+            CountryFlag("de")
+            CountryFlag("us", size: .small)
+            CountryFlag("us", size: .custom(.xxxLarge))
+            CountryFlag("unknown", size: .xLarge)
         }
         .padding()
         .previewLayout(.sizeThatFits)

--- a/Sources/Orbit/Components/Heading.swift
+++ b/Sources/Orbit/Components/Heading.swift
@@ -9,32 +9,18 @@ import SwiftUI
 /// - Important: Component has fixed vertical size.
 public struct Heading: View {
 
-    public static let spacing: CGFloat = .xSmall
-
     let label: String
-    let iconContent: Icon.Content
     let style: Style
     let color: Color?
     let alignment: TextAlignment
 
     public var body: some View {
-        
-        if text.isEmpty == false || iconContent.isEmpty == false {
-            
-            HStack(alignment: .firstTextBaseline, spacing: Self.spacing) {
-                iconContent.view()
-                    .alignmentGuide(.firstTextBaseline) { size in
-                        self.style.size * Text.firstBaselineRatio + size.height / 2
-                    }
-
-                if text.isEmpty == false {
-                    SwiftUI.Text(verbatim: text)
-                        .font(.orbit(size: style.size, weight: style.weight))
-                        .foregroundColor(color?.value)
-                        .multilineTextAlignment(alignment)
-                        .fixedSize(horizontal: false, vertical: true)
-                }
-            }
+        if text.isEmpty == false {
+            SwiftUI.Text(verbatim: text)
+                .font(.orbit(size: style.size, weight: style.weight))
+                .foregroundColor(color?.value)
+                .multilineTextAlignment(alignment)
+                .fixedSize(horizontal: false, vertical: true)
         }
     }
 
@@ -52,28 +38,11 @@ public extension Heading {
     /// Creates Orbit Heading component.
     init(
         _ label: String,
-        iconContent: Icon.Content = .none,
         style: Style,
         color: Color? = .inkNormal,
         alignment: TextAlignment = .leading
     ) {
         self.label = label
-        self.iconContent = iconContent
-        self.style = style
-        self.color = color
-        self.alignment = alignment
-    }
-
-    /// Creates Orbit Heading component with icon symbol.
-    init(
-        _ label: String,
-        icon: Icon.Symbol,
-        style: Style,
-        color: Color? = .inkNormal,
-        alignment: TextAlignment = .leading
-    ) {
-        self.label = label
-        self.iconContent = .icon(icon, size: .custom(style.size), color: color?.value)
         self.style = style
         self.color = color
         self.alignment = alignment
@@ -142,8 +111,9 @@ struct HeadingPreviews: PreviewProvider {
         PreviewWrapper {
             standalone
             
-            Heading("Heading", icon: .grid, style: .title1, color: .none)
+            Label("Heading", icon: .grid, titleStyle: .heading(.title1, color: nil))
                 .foregroundColor(.blueNormal)
+                .previewDisplayName("Label with color override")
             
             snapshots
         }
@@ -175,18 +145,21 @@ struct HeadingPreviews: PreviewProvider {
                 .padding(.vertical)
 
             VStack(alignment: .leading, spacing: .xSmall) {
-                Heading("Display title, but very very very very very very very long", icon: .circle, style: .display)
-                Heading("Display subtitle, also very very very very very long", icon: .email, style: .displaySubtitle)
+                Label("Display title, but very very very very very very very long", icon: .circle, titleStyle: .display)
+                
+                Label("Display title, but very very very very very very very long", icon: .circle, titleStyle: .display)
+                
+                Label("Display subtitle, also very very very very very long", icon: .email, titleStyle: .displaySubtitle)
                 Separator()
-                Heading("Title 1, also very very very very very very very verylong", icon: .circle, style: .title1)
-                Heading("Title 2, but very very very very very very very very long", icon: .circle, style: .title2)
-                Heading("Title 3, but very very very very very very very very long", icon: .circle, style: .title3)
-                Heading("Title 4, but very very very very very very very very long", icon: .circle, style: .title4)
-                Heading("Title 5, but very very very very very very very very long", icon: .circle, style: .title5)
-                Heading("Title 6, but very very very very very very very very long", icon: .circle, style: .title6)
+                Label("Title 1, also very very very very very very very verylong", icon: .circle, titleStyle: .title1)
+                Label("Title 2, but very very very very very very very very long", icon: .circle, titleStyle: .title2)
+                Label("Title 3, but very very very very very very very very long", icon: .circle, titleStyle: .title3)
+                Label("Title 4, but very very very very very very very very long", icon: .circle, titleStyle: .title4)
+                Label("Title 5, but very very very very very very very very long", icon: .circle, titleStyle: .title5)
+                Label("Title 6, but very very very very very very very very long", icon: .circle, titleStyle: .title6)
             }
             .padding(.vertical)
-            .previewDisplayName("Longer text")
+            .previewDisplayName("Longer text with icon using Label")
         }
         .padding(.horizontal)
     }

--- a/Sources/Orbit/Components/Heading.swift
+++ b/Sources/Orbit/Components/Heading.swift
@@ -94,6 +94,19 @@ public extension Heading {
                 case .title6:           return Text.Size.small.value
             }
         }
+        
+        public var lineHeight: CGFloat {
+            switch self {
+                case .display:          return 48
+                case .displaySubtitle:  return 28
+                case .title1:           return 32
+                case .title2:           return 28
+                case .title3:           return Text.Size.large.lineHeight
+                case .title4:           return Text.Size.normal.lineHeight
+                case .title5:           return Text.Size.normal.lineHeight
+                case .title6:           return Text.Size.small.lineHeight
+            }
+        }
 
         public var weight: Font.Weight {
             switch self {

--- a/Sources/Orbit/Components/Icon.swift
+++ b/Sources/Orbit/Components/Icon.swift
@@ -46,7 +46,7 @@ public extension Icon {
     }
     
     /// Creates Orbit Icon component for provided icon symbol.
-    init(_ symbol: Icon.Symbol, size: Size = .medium, color: Color? = .inkLighter) {
+    init(_ symbol: Icon.Symbol, size: Size = .normal, color: Color? = .inkLighter) {
         self.init(.icon(symbol, size: size, color: color))
     }
 }
@@ -58,11 +58,11 @@ public extension Icon {
     enum Content: Equatable {
         case none
         /// Orbit icon symbol with size and optional overrideable color.
-        case icon(Symbol, size: Size = .medium, color: Color? = nil)
+        case icon(Symbol, size: Size = .normal, color: Color? = nil)
         /// Icon using custom Image.
-        case image(Image, size: Size = .medium, mode: ContentMode = .fit)
+        case image(Image, size: Size = .normal, mode: ContentMode = .fit)
         /// Orbit illustration.
-        case illustration(Illustration.Image, size: Size = .large)
+        case illustration(Illustration.Image, size: Size = .xLarge)
         /// Orbit CountryFlag.
         case countryFlag(String, size: Size = .normal)
         
@@ -78,14 +78,14 @@ public extension Icon {
     }
 
     enum Size: Equatable {
-        /// Size 16
+        /// Size 16.
         case small
-        /// Size 20
-        case `default`
-        /// Size 24
-        case medium
-        /// Size 32
+        /// Size 20.
+        case normal
+        /// Size 24.
         case large
+        /// Size 28.
+        case xLarge
         /// Size based on Font size.
         case fontSize(CGFloat)
         /// Size based on Header.Title style.
@@ -96,9 +96,9 @@ public extension Icon {
         public var value: CGFloat {
             switch self {
                 case .small:                return 16
-                case .default:              return 20
-                case .medium:               return 24
-                case .large:                return 32
+                case .normal:               return 20
+                case .large:                return 24
+                case .xLarge:               return 28
                 case .fontSize(let size):   return size + 1
                 case .header(let style):    return style.size + 1
                 case .custom(let size):     return size
@@ -117,62 +117,49 @@ struct IconPreviews: PreviewProvider {
     static var previews: some View {
         PreviewWrapper {
             standalone
-
             snapshots
-
-            ScrollView {
-                orbit
-                    .padding()
-            }
         }
+        .previewLayout(.sizeThatFits)
     }
 
     static var standalone: some View {
         Icon(.informationCircle)
-            .previewLayout(.sizeThatFits)
     }
-
+    
     static var orbit: some View {
-        VStack(spacing: .small) {
-            ForEach(Icon.Symbol.allCases.sorted(), id: \.self) { icon in
-                HStack {
-                    Text("\(icon)", size: .normal)
-                        .layoutPriority(1)
-                    Separator()
-                    Icon(icon, size: .large, color: .inkNormal)
-                    Icon(icon)
-                    Icon(icon, size: .small, color: .inkLightActive)
-                    Icon(icon, size: .small, color: nil)
-                        .foregroundColor(.redNormal)
-                }
-            }
-        }
-        .previewDisplayName("Icons")
+        snapshots
     }
 
     static var snapshots: some View {
         VStack(spacing: .small) {
             HStack {
-                Icon(.flightNomad, size: .large)
+                Icon(.flightNomad, size: .xLarge)
                 Icon(.flightNomad)
                 Icon(.flightNomad, size: .small)
             }
 
             HStack {
-                Icon(.informationCircle, size: .large, color: .inkNormal)
+                Icon(.informationCircle, size: .xLarge, color: .inkNormal)
                 Icon(.informationCircle, color: .inkNormal)
                 Icon(.informationCircle, size: .small, color: .inkNormal)
             }
 
             HStack {
-                Icon(.airplaneUp, size: .large, color: .blueDark)
-                Icon(.airplaneUp, color: .blueDark)
-                Icon(.airplaneUp, size: .small, color: .blueDark)
+                Icon(.grid, size: .xLarge, color: nil)
+                Icon(.grid)
+                Icon(.grid, size: .small, color: .red)
+            }
+            .foregroundColor(.blueDark)
+            
+            Separator()
+            
+            HStack {
+                Icon(.image(.orbit(.facebook)))
+                Icon(.countryFlag("cz", size: .normal))
+                Icon(.illustration(.womanWithPhone, size: .custom(60)))
             }
         }
-        .previewDisplayName("Icon sizes")
         .frame(width: 120)
         .padding()
-        .previewLayout(.sizeThatFits)
     }
 }

--- a/Sources/Orbit/Components/Icon.swift
+++ b/Sources/Orbit/Components/Icon.swift
@@ -94,20 +94,22 @@ public extension Icon {
         case xLarge
         /// Size based on Font size.
         case fontSize(CGFloat)
-        /// Size based on Header.Title style.
-        case header(Label.TitleStyle)
+        /// Size based on `Label.Title` style.
+        case label(Label.TitleStyle)
         /// Custom size
         case custom(CGFloat)
         
         public var value: CGFloat {
             switch self {
-                case .small:                return 16
-                case .normal:               return 20
-                case .large:                return 24
-                case .xLarge:               return 28
-                case .fontSize(let size):   return size + 1
-                case .header(let style):    return style.size + 1
-                case .custom(let size):     return size
+                case .small:                            return 16
+                case .normal:                           return 20
+                case .large:                            return 24
+                case .xLarge:                           return 28
+                case .fontSize(let size):               return size + 1
+                case .label(.heading(let style, _)):    return style.lineHeight
+                case .label(.text(let style, _, _)):    return style.lineHeight
+                case .label(let style):                 return style.size + 1
+                case .custom(let size):                 return size
             }
         }
         

--- a/Sources/Orbit/Components/Icon.swift
+++ b/Sources/Orbit/Components/Icon.swift
@@ -8,17 +8,28 @@ import SwiftUI
 /// - Note: [Orbit definition](https://orbit.kiwi/components/icon/)
 public struct Icon: View {
 
-    let symbol: Icon.Symbol
-    let size: Size
-    let color: Color?
+    let content: Icon.Content
 
     public var body: some View {
-        if symbol == .none {
+        if content.isEmpty {
             EmptyView()
         } else {
-            SwiftUI.Text(verbatim: symbol.value)
-                .font(.orbitIcon(size: size.value))
-                .foregroundColor(color)
+            switch content {
+                case .icon(let symbol, let size, let color):
+                    SwiftUI.Text(verbatim: symbol.value)
+                        .font(.orbitIcon(size: size.value))
+                        .foregroundColor(color)
+                case .image(let image, let size, let mode):
+                    image
+                        .resizable()
+                        .aspectRatio(contentMode: mode)
+                        .frame(width: size.value, height: size.value)
+                case .illustration(let illlustration, let size):
+                    Illustration(illlustration, layout: .resizeable)
+                        .frame(width: size.value, height: size.value)
+                case .none:
+                    EmptyView()
+            }
         }
     }
 }
@@ -26,11 +37,14 @@ public struct Icon: View {
 // MARK: - Inits
 public extension Icon {
     
+    /// Creates Orbit Icon component for provided icon content.
+    init(_ content: Icon.Content) {
+        self.content = content
+    }
+    
     /// Creates Orbit Icon component for provided icon symbol.
     init(_ symbol: Icon.Symbol, size: Size = .medium, color: Color? = .inkLighter) {
-        self.symbol = symbol
-        self.size = size
-        self.color = color
+        self.init(.icon(symbol, size: size, color: color))
     }
 }
 
@@ -46,23 +60,6 @@ public extension Icon {
         case image(Image, size: Size = .medium, mode: ContentMode = .fit)
         /// Orbit illustration.
         case illustration(Illustration.Image, size: Size = .large)
-
-        @ViewBuilder public func view(defaultColor: Color? = nil) -> some View {
-            switch self {
-                case .icon(let icon, let size, let color):
-                    Icon(icon, size: size, color: color ?? defaultColor)
-                case .image(let image, let size, let mode):
-                    image
-                        .resizable()
-                        .aspectRatio(contentMode: mode)
-                        .frame(width: size.value, height: size.value)
-                case .illustration(let illlustration, let size):
-                    Illustration(illlustration, layout: .resizeable)
-                        .frame(width: size.value, height: size.value)
-                case .none:
-                    EmptyView()
-            }
-        }
         
         public var isEmpty: Bool {
             switch self {

--- a/Sources/Orbit/Components/Icon.swift
+++ b/Sources/Orbit/Components/Icon.swift
@@ -8,6 +8,7 @@ import SwiftUI
 /// - Note: [Orbit definition](https://orbit.kiwi/components/icon/)
 public struct Icon: View {
 
+    public static let averagePadding: CGFloat = .xxxSmall
     let content: Icon.Content
 
     public var body: some View {
@@ -27,6 +28,8 @@ public struct Icon: View {
                 case .illustration(let illlustration, let size):
                     Illustration(illlustration, layout: .resizeable)
                         .frame(width: size.value, height: size.value)
+                case .countryFlag(let countryCode, let size):
+                    CountryFlag(countryCode, size: size)
                 case .none:
                     EmptyView()
             }
@@ -60,6 +63,8 @@ public extension Icon {
         case image(Image, size: Size = .medium, mode: ContentMode = .fit)
         /// Orbit illustration.
         case illustration(Illustration.Image, size: Size = .large)
+        /// Orbit CountryFlag.
+        case countryFlag(String, size: Size = .normal)
         
         public var isEmpty: Bool {
             switch self {
@@ -67,6 +72,7 @@ public extension Icon {
                 case .icon(let symbol, _, _):           return symbol == .none
                 case .illustration(let image, _):       return image == .none
                 case .image:                            return false
+                case .countryFlag(let countryCode, _):  return countryCode.isEmpty
             }
         }
     }

--- a/Sources/Orbit/Components/Icon.swift
+++ b/Sources/Orbit/Components/Icon.swift
@@ -18,8 +18,8 @@ public struct Icon: View {
             switch content {
                 case .icon(let symbol, let size, let color):
                     SwiftUI.Text(verbatim: symbol.value)
-                        .font(.orbitIcon(size: size.value))
                         .foregroundColor(color)
+                        .font(.orbitIcon(size: size.value))
                 case .image(let image, let size, let mode):
                     image
                         .resizable()
@@ -30,6 +30,9 @@ public struct Icon: View {
                         .frame(width: size.value, height: size.value)
                 case .countryFlag(let countryCode, let size):
                     CountryFlag(countryCode, size: size)
+                case .sfSymbol(let systemName, let size):
+                    Image(systemName: systemName)
+                        .font(.system(size: size.value - 2 * Self.averagePadding))
                 case .none:
                     EmptyView()
             }
@@ -65,6 +68,8 @@ public extension Icon {
         case illustration(Illustration.Image, size: Size = .xLarge)
         /// Orbit CountryFlag.
         case countryFlag(String, size: Size = .normal)
+        /// SwiftUI SF Symbol.
+        case sfSymbol(String, size: Size = .normal)
         
         public var isEmpty: Bool {
             switch self {
@@ -73,6 +78,7 @@ public extension Icon {
                 case .illustration(let image, _):       return image == .none
                 case .image:                            return false
                 case .countryFlag(let countryCode, _):  return countryCode.isEmpty
+                case .sfSymbol(let systemName, _):      return systemName.isEmpty
             }
         }
     }
@@ -156,7 +162,18 @@ struct IconPreviews: PreviewProvider {
             HStack {
                 Icon(.image(.orbit(.facebook)))
                 Icon(.countryFlag("cz", size: .normal))
-                Icon(.illustration(.womanWithPhone, size: .custom(60)))
+                Icon(.illustration(.womanWithPhone, size: .normal))
+            }
+            
+            HStack(spacing: .xxSmall) {
+                Icon(.sfSymbol("info.circle.fill", size: .normal))
+                    .foregroundColor(.greenNormal)
+                Icon(.informationCircle, size: .normal, color: nil)
+                    .foregroundColor(.greenNormal)
+                Icon(.sfSymbol("info.circle.fill", size: .xLarge))
+                    .foregroundColor(.greenNormal)
+                Icon(.informationCircle, size: .xLarge, color: nil)
+                    .foregroundColor(.greenNormal)
             }
         }
         .frame(width: 120)

--- a/Sources/Orbit/Components/InputField.swift
+++ b/Sources/Orbit/Components/InputField.swift
@@ -191,6 +191,7 @@ struct InputFieldPreviews: PreviewProvider {
         )
         InputField(value: .constant("InputField with no label"))
         standalone
+        InputField(value: .constant("InputField with CountryFlag prefix"), prefix: .countryFlag("us", size: .normal))
     }
 
     static var snapshots: some View {

--- a/Sources/Orbit/Components/ListChoice.swift
+++ b/Sources/Orbit/Components/ListChoice.swift
@@ -84,7 +84,7 @@ public struct ListChoice<Content: View>: View {
             case .none:
                 EmptyView()
             case .disclosure(let color):
-                Icon(.chevronRight, size: .medium, color: color)
+                Icon(.chevronRight, size: .large, color: color)
                     .padding(.leading, -.xSmall)
             case .button(let type):
                 disclosureButton(type: type)
@@ -176,7 +176,7 @@ public extension ListChoice {
         self.init(
             title,
             description: description,
-            icon: .icon(icon, size: .default, color: .inkNormal),
+            icon: .icon(icon, color: .inkNormal),
             disclosure: disclosure,
             showSeparator: showSeparator,
             action: action,
@@ -216,7 +216,7 @@ public extension ListChoice {
         self.init(
             title,
             description: description,
-            icon: .icon(icon, size: .default, color: .inkNormal),
+            icon: .icon(icon, color: .inkNormal),
             disclosure: disclosure,
             showSeparator: showSeparator,
             action: action
@@ -254,7 +254,7 @@ public extension ListChoice {
         self.init(
             title,
             description: description,
-            icon: .icon(icon, size: .default, color: .inkNormal),
+            icon: .icon(icon, color: .inkNormal),
             value: value,
             disclosure: disclosure,
             showSeparator: showSeparator,
@@ -319,9 +319,9 @@ struct ListChoicePreviews: PreviewProvider {
             ListChoice(title, description: description, disclosure: .none)
             ListChoice(title, description: "No Separator", disclosure: .none, showSeparator: false)
             ListChoice(title, icon: .airplane, disclosure: .none)
-            ListChoice(title, icon: .icon(.airplane, size: .medium, color: .inkLighter), disclosure: .none)
-            ListChoice(title, description: description, icon: .airplane, value: value, disclosure: .none)
+            ListChoice(title, icon: .icon(.airplane, size: .xLarge, color: .blueNormal), disclosure: .none)
             ListChoice(title, description: description, icon: .countryFlag("cs"), disclosure: .none)
+            ListChoice(title, description: description, icon: .grid, value: value, disclosure: .none)
             ListChoice(title, description: description, disclosure: .none) {
                 badge
             }
@@ -399,7 +399,7 @@ struct ListChoicePreviews: PreviewProvider {
                 .background(Color.white)
             ListChoice(title, icon: .airplane, disclosure: .none)
                 .background(Color.white)
-            ListChoice(title, icon: .icon(.airplane, size: .medium, color: .inkLighter), disclosure: .none)
+            ListChoice(title, icon: .icon(.airplane, size: .large, color: .inkLighter), disclosure: .none)
                 .background(Color.white)
             ListChoice(title, description: description, icon: .airplane, disclosure: .none)
                 .background(Color.white)

--- a/Sources/Orbit/Components/ListChoice.swift
+++ b/Sources/Orbit/Components/ListChoice.swift
@@ -320,8 +320,8 @@ struct ListChoicePreviews: PreviewProvider {
             ListChoice(title, description: "No Separator", disclosure: .none, showSeparator: false)
             ListChoice(title, icon: .airplane, disclosure: .none)
             ListChoice(title, icon: .icon(.airplane, size: .medium, color: .inkLighter), disclosure: .none)
-            ListChoice(title, description: description, icon: .airplane, disclosure: .none)
             ListChoice(title, description: description, icon: .airplane, value: value, disclosure: .none)
+            ListChoice(title, description: description, icon: .countryFlag("cs"), disclosure: .none)
             ListChoice(title, description: description, disclosure: .none) {
                 badge
             }

--- a/Sources/Orbit/Components/ListChoice.swift
+++ b/Sources/Orbit/Components/ListChoice.swift
@@ -84,7 +84,7 @@ public struct ListChoice<Content: View>: View {
             case .none:
                 EmptyView()
             case .disclosure(let color):
-                Icon(symbol: .chevronRight, size: .medium, color: color)
+                Icon(.chevronRight, size: .medium, color: color)
                     .padding(.leading, -.xSmall)
             case .button(let type):
                 disclosureButton(type: type)

--- a/Sources/Orbit/Components/ListItem.swift
+++ b/Sources/Orbit/Components/ListItem.swift
@@ -18,7 +18,7 @@ public struct ListItem: View {
 
     public var body: some View {
         HStack(alignment: .firstTextBaseline, spacing: spacing) {
-            iconContent.view()
+            Icon(iconContent)
                 .alignmentGuide(.firstTextBaseline) { size in
                     self.size.value * Text.firstBaselineRatio + size.height / 2
                 }

--- a/Sources/Orbit/Components/ListItem.swift
+++ b/Sources/Orbit/Components/ListItem.swift
@@ -33,10 +33,11 @@ public struct ListItem: View {
     var iconSize: Icon.Size? {
         switch iconContent {
             case .none:                                 return nil
-            case .icon(_, size: let size, _):           return size
-            case .image(_, size: let size, _):          return size
-            case .illustration(_, size: let size):      return size
-            case .countryFlag(_, size: let size):       return size
+            case .icon(_, let size, _):                 return size
+            case .image(_, let size, _):                return size
+            case .illustration(_, let size):            return size
+            case .countryFlag(_, let size):             return size
+            case .sfSymbol(_, let size):                return size
         }
     }
 }
@@ -75,7 +76,7 @@ public extension ListItem {
     ) {
         self.init(
             text,
-            iconContent: .icon(icon, size: .small, color: Color(style.textColor.value)),
+            iconContent: .icon(icon, size: .small, color: style.textColor.value),
             size: size,
             spacing: spacing,
             style: style,

--- a/Sources/Orbit/Components/ListItem.swift
+++ b/Sources/Orbit/Components/ListItem.swift
@@ -36,6 +36,7 @@ public struct ListItem: View {
             case .icon(_, size: let size, _):           return size
             case .image(_, size: let size, _):          return size
             case .illustration(_, size: let size):      return size
+            case .countryFlag(_, size: let size):       return size
         }
     }
 }

--- a/Sources/Orbit/Components/Select.swift
+++ b/Sources/Orbit/Components/Select.swift
@@ -65,7 +65,7 @@ public extension Select {
         prefix: Icon.Content = .none,
         value: String?,
         placeholder: String = "",
-        suffix: Icon.Content = .icon(.chevronDown, size: .medium),
+        suffix: Icon.Content = .icon(.chevronDown, size: .large),
         state: InputState = .default,
         message: MessageType = .none,
         action: @escaping () -> Void = {}

--- a/Sources/Orbit/Components/Text.swift
+++ b/Sources/Orbit/Components/Text.swift
@@ -167,6 +167,16 @@ public extension Text {
                 case .custom(let size):     return size
             }
         }
+        
+        public var lineHeight: CGFloat {
+            switch self {
+                case .small:                return 16
+                case .normal:               return 20
+                case .large:                return 24
+                case .xLarge:               return 24
+                case .custom(let size):     return size + 4
+            }
+        }
     }
 
     enum Color: Equatable {

--- a/Sources/Orbit/Components/Text.swift
+++ b/Sources/Orbit/Components/Text.swift
@@ -79,7 +79,7 @@ public struct Text: View {
     }
 
     var foregroundColor: UIColor? {
-        color?.value
+        color?.uiValue
     }
 
     var attributedText: NSAttributedString {
@@ -137,7 +137,7 @@ public extension Text {
         self.weight = weight
         self.lineSpacing = lineSpacing
         self.alignment = alignment
-        self.accentColor = accentColor ?? color?.value ?? .inkNormal
+        self.accentColor = accentColor ?? color?.uiValue ?? .inkNormal
         self.linkColor = linkColor
         self.isSelectable = isSelectable
         self.linkAction = linkAction
@@ -175,7 +175,11 @@ public extension Text {
         case white
         case custom(UIColor)
 
-        var value: UIColor {
+        var value: SwiftUI.Color {
+            SwiftUI.Color(uiValue)
+        }
+        
+        var uiValue: UIColor {
             switch self {
                 case .inkNormal:            return .inkNormal
                 case .inkLight:             return .inkLight

--- a/Sources/Orbit/Components/Tile.swift
+++ b/Sources/Orbit/Components/Tile.swift
@@ -222,7 +222,7 @@ public extension Tile {
     ) {
         self.title = title
         self.description = description
-        self.iconContent = .icon(icon, size: .header(titleStyle), color: iconColor)
+        self.iconContent = .icon(icon, size: .label(titleStyle), color: iconColor)
         self.disclosure = disclosure
         self.border = border
         self.status = status

--- a/Sources/Orbit/Components/TimelineStep.swift
+++ b/Sources/Orbit/Components/TimelineStep.swift
@@ -8,7 +8,7 @@ import SwiftUI
 /// - Note: [Orbit definition](https://orbit.kiwi/components/progress-indicators/timeline/)
 public struct TimelineStep: View {
 
-    public static let indicatorDiameter: CGFloat = Icon.Size.medium.value
+    public static let indicatorDiameter: CGFloat = Icon.Size.large.value
 
     let label: String
     let sublabel: String
@@ -18,7 +18,7 @@ public struct TimelineStep: View {
     public var body: some View {
         HStack(alignment: .top, spacing: .small) {
             Color.clear
-                .frame(width: Icon.Size.medium.value, height: Icon.Size.medium.value)
+                .frame(width: Icon.Size.large.value, height: Icon.Size.large.value)
                 .overlay(indicator)
 
             VStack(alignment: .leading, spacing: .xSmall) {
@@ -53,7 +53,7 @@ public struct TimelineStep: View {
                     .strokeBorder(Color.cloudNormalHover, lineWidth: 2)
                     .frame(width: .small, height: .small)
             case .status:
-                Icon(style.icon, size: .medium, color: style.color)
+                Icon(style.icon, size: .large, color: style.color)
         }
     }
 

--- a/Sources/Orbit/Support/Forms/InputStyle.swift
+++ b/Sources/Orbit/Support/Forms/InputStyle.swift
@@ -36,7 +36,8 @@ struct InputContent<Content: View>: View {
     
     var body: some View {
         HStack(spacing: 0) {
-            prefix.view(defaultColor: prefixColor)
+            Icon(prefix)
+                .foregroundColor(prefixColor)
                 .padding(.horizontal, .xSmall)
 
             label()
@@ -45,7 +46,8 @@ struct InputContent<Content: View>: View {
 
             Spacer(minLength: 0)
 
-            suffix.view(defaultColor: suffixColor)
+            Icon(suffix)
+                .foregroundColor(suffixColor)
                 .padding(.horizontal, .xSmall)
                 .contentShape(Rectangle())
                 .onTapGesture(perform: suffixAction)

--- a/Sources/Orbit/Support/Views/BarButton.swift
+++ b/Sources/Orbit/Support/Views/BarButton.swift
@@ -12,7 +12,7 @@ public struct BarButton: View {
                 action()
             },
             label: {
-                Icon.Content.icon(symbol, size: .medium, color: .inkNormal).view()
+                Icon(symbol, size: .medium, color: .inkNormal)
             }
         )
         .buttonStyle(NavigateButton.OrbitStyle())

--- a/Sources/Orbit/Support/Views/BarButton.swift
+++ b/Sources/Orbit/Support/Views/BarButton.swift
@@ -12,7 +12,7 @@ public struct BarButton: View {
                 action()
             },
             label: {
-                Icon(symbol, size: .medium, color: .inkNormal)
+                Icon(symbol, size: .large, color: .inkNormal)
             }
         )
         .buttonStyle(NavigateButton.OrbitStyle())

--- a/Sources/Orbit/Support/Views/Label.swift
+++ b/Sources/Orbit/Support/Views/Label.swift
@@ -62,7 +62,7 @@ public struct Label: View {
 // MARK: - Inits
 public extension Label {
 
-    /// Creates Orbit Header component for Tile or Card usage.
+    /// Creates Orbit Label component.
     init(
         _ title: String = "",
         description: String = "",
@@ -83,7 +83,7 @@ public extension Label {
         self.descriptionLinkAction = descriptionLinkAction
     }
 
-    /// Creates Orbit Header component for Tile or Card usage.
+    /// Creates Orbit Label component.
     init(
         _ title: String = "",
         description: String = "",
@@ -97,7 +97,7 @@ public extension Label {
         self.init(
             title: title,
             description: description,
-            iconContent: .icon(icon, size: .header(titleStyle)),
+            iconContent: .icon(icon, size: .header(titleStyle), color: titleStyle.color),
             titleStyle: titleStyle,
             descriptionStyle: descriptionStyle,
             iconSpacing: iconSpacing,
@@ -128,6 +128,13 @@ public extension Label {
             switch self {
                 case .heading(let style, _):            return style.size
                 case .text(let size, _, _):             return size.value
+            }
+        }
+        
+        var color: Color? {
+            switch self {
+                case .heading(_ , let color):           return color?.value
+                case .text(_, _, let color):            return color?.value
             }
         }
     }
@@ -176,9 +183,12 @@ struct HeaderPreviews: PreviewProvider {
                 Label()
                 Label("Label")
                 Label("Label", description: "Description")
-                Label("Label", description: "Description", descriptionStyle: .custom(.large))
-                Label("Label", description: "Description", icon: .grid)
-                Label("Label", description: "Description", iconContent: .countryFlag("us"))
+                Label("No Icon", description: "Description", descriptionStyle: .custom(.large))
+                Label("Orbit Icon", description: "Description", icon: .informationCircle, titleStyle: .heading(.title4, color: .none))
+                    .foregroundColor(.blueNormal)
+                Label("SF Symbol", description: "Description", iconContent: .sfSymbol("info.circle.fill"), titleStyle: .heading(.title4, color: .none))
+                    .foregroundColor(.blueNormal)
+                Label("CountryFlag", description: "Description", iconContent: .countryFlag("us"), titleStyle: .heading(.title4, color: .custom(.blueNormal)))
                 
                 Label(
                     "Label",

--- a/Sources/Orbit/Support/Views/Label.swift
+++ b/Sources/Orbit/Support/Views/Label.swift
@@ -18,7 +18,7 @@ public struct Label: View {
     public var body: some View {
         if isEmpty == false {
             HStack(alignment: .firstTextBaseline, spacing: iconSpacing) {
-                iconContent.view()
+                Icon(iconContent)
                     .alignmentGuide(.firstTextBaseline) { size in
                         self.titleStyle.size * Text.firstBaselineRatio + size.height / 2
                     }

--- a/Sources/Orbit/Support/Views/Label.swift
+++ b/Sources/Orbit/Support/Views/Label.swift
@@ -178,6 +178,7 @@ struct HeaderPreviews: PreviewProvider {
                 Label("Label", description: "Description")
                 Label("Label", description: "Description", descriptionStyle: .custom(.large))
                 Label("Label", description: "Description", icon: .grid)
+                Label("Label", description: "Description", iconContent: .countryFlag("us"))
                 
                 Label(
                     "Label",

--- a/Sources/Orbit/Support/Views/Label.swift
+++ b/Sources/Orbit/Support/Views/Label.swift
@@ -97,7 +97,7 @@ public extension Label {
         self.init(
             title: title,
             description: description,
-            iconContent: .icon(icon, size: .header(titleStyle), color: titleStyle.color),
+            iconContent: .icon(icon, size: .label(titleStyle), color: titleStyle.color),
             titleStyle: titleStyle,
             descriptionStyle: descriptionStyle,
             iconSpacing: iconSpacing,
@@ -188,7 +188,8 @@ struct HeaderPreviews: PreviewProvider {
                     .foregroundColor(.blueNormal)
                 Label("SF Symbol", description: "Description", iconContent: .sfSymbol("info.circle.fill"), titleStyle: .heading(.title4, color: .none))
                     .foregroundColor(.blueNormal)
-                Label("CountryFlag", description: "Description", iconContent: .countryFlag("us"), titleStyle: .heading(.title4, color: .custom(.blueNormal)))
+                Label("CountryFlag", description: "Description", iconContent: .countryFlag("us"), titleStyle: .heading(.title4, color: .none))
+                    .foregroundColor(.blueNormal)
                 
                 Label(
                     "Label",


### PR DESCRIPTION
There are new and updated icon sizes. Code has been refactored to unify all icon-related images to use the same Icon size enum. Added CountryFlag as one of Icon options.

<img width="738" alt="image" src="https://user-images.githubusercontent.com/35844477/158630272-59fbb639-92d8-47ed-987b-3042978f4c62.png">

<img width="305" alt="image" src="https://user-images.githubusercontent.com/35844477/158629184-bc65c63a-7f30-4bc6-ac02-36a44bdaef19.png">

<img width="296" alt="image" src="https://user-images.githubusercontent.com/35844477/158629506-915dc525-08f4-414a-bf0c-a77037843e0b.png">

<img width="952" alt="image" src="https://user-images.githubusercontent.com/35844477/158629890-c9bf3a4f-fc88-4452-8c48-167721e0f925.png">

<img width="577" alt="image" src="https://user-images.githubusercontent.com/35844477/158630126-ff3dc9c5-72b9-4445-9101-991cb98328c4.png">

<img width="319" alt="image" src="https://user-images.githubusercontent.com/35844477/158631296-9b787aaa-f9f7-450e-bdb3-6c802ed9fa46.png">

<img width="329" alt="image" src="https://user-images.githubusercontent.com/35844477/158693335-96848bac-e1f3-4037-97d8-d35d2356e86f.png">
