### PR TITLE
Fixes for upcoming 0.8.14

### DIFF
--- a/Sources/Orbit/Components/Alert.swift
+++ b/Sources/Orbit/Components/Alert.swift
@@ -50,6 +50,7 @@ public struct Alert<Content: View>: View {
                 iconContent: .icon(icon, color: status.color),
                 titleStyle: .text(weight: .bold),
                 descriptionStyle: .custom(.normal, color: .inkNormal, linkColor: .inkNormal),
+                descriptionSpacing: .xxSmall,
                 descriptionLinkAction: descriptionLinkAction
             )
             

--- a/Sources/Orbit/Components/Badge.swift
+++ b/Sources/Orbit/Components/Badge.swift
@@ -22,7 +22,7 @@ public struct Badge: View {
     public var body: some View {
         if isEmpty == false {
             HStack(spacing: size.spacing) {
-                Icon(iconContent)
+                Icon(iconContent, size: .small)
                 
                 Text(
                     label,
@@ -67,7 +67,7 @@ public extension Badge {
     init(_ label: String = "", icon: Icon.Symbol = .none, style: Style = .neutral, size: Size = .default) {
         self.init(
             label,
-            iconContent: .icon(icon, size: .small, color: Color(style.labelColor)),
+            iconContent: .icon(icon, color: Color(style.labelColor)),
             style: style,
             size: size
         )
@@ -265,7 +265,7 @@ struct BadgePreviews: PreviewProvider {
 
                 Badge(
                     "Custom",
-                    iconContent: .icon(.airplane, size: .small, color: .pink),
+                    iconContent: .icon(.airplane, color: .pink),
                     style: .custom(
                         labelColor: .blueDark,
                         outlineColor: .blueDark,

--- a/Sources/Orbit/Components/BadgeList.swift
+++ b/Sources/Orbit/Components/BadgeList.swift
@@ -22,7 +22,9 @@ public struct BadgeList: View {
     public var body: some View {
         HStack(alignment: .firstTextBaseline, spacing: Self.spacing) {
             badgeBackground
-                .overlay(Icon(iconContent))
+                .overlay(
+                    Icon(iconContent, size: .small)
+                )
                 .alignmentGuide(.firstTextBaseline) { size in
                     Text.Size.small.value * Text.firstBaselineRatio + size.height / 2
                 }
@@ -63,7 +65,7 @@ public extension BadgeList {
     init(_ label: String = "", icon: Icon.Symbol = .none, style: Style = .neutral, labelColor: LabelColor = .default) {
         self.init(
             label,
-            iconContent: .icon(icon, size: .small, color: style.iconColor),
+            iconContent: .icon(icon, color: style.iconColor),
             style: style,
             labelColor: labelColor
         )

--- a/Sources/Orbit/Components/Button.swift
+++ b/Sources/Orbit/Components/Button.swift
@@ -30,7 +30,7 @@ public struct Button: View {
                         Spacer(minLength: 0)
                     }
 
-                    Icon(iconContent)
+                    Icon(iconContent, size: iconSize)
 
                     if #available(iOS 14.0, *) {
                         Text(
@@ -54,7 +54,7 @@ public struct Button: View {
 
                     Spacer(minLength: 0)
 
-                    Icon(disclosureIconContent)
+                    Icon(disclosureIconContent, size: iconSize)
                 }
                 .padding(.horizontal, label.isEmpty ? 0 : size.padding)
             }
@@ -66,6 +66,10 @@ public struct Button: View {
 
     var isIconOnly: Bool {
         iconContent.isEmpty == false && label.isEmpty
+    }
+    
+    var iconSize: Icon.Size {
+        size == .small ? .small : .large
     }
 
     func presentHapticFeedback() {
@@ -113,13 +117,12 @@ public extension Button {
         disclosureIcon: Icon.Symbol = .none,
         action: @escaping () -> Void = {}
     ) {
-        let iconSize: Icon.Size = size == .small ? .small : .large
         self.init(
             label,
             style: style,
             size: size,
-            iconContent: .icon(icon, size: iconSize, color: style.foregroundColor),
-            disclosureIconContent: .icon(disclosureIcon, size: iconSize, color: style.foregroundColor),
+            iconContent: .icon(icon, color: style.foregroundColor),
+            disclosureIconContent: .icon(disclosureIcon, color: style.foregroundColor),
             action: action
         )
     }
@@ -393,7 +396,7 @@ struct ButtonPreviews: PreviewProvider {
             Button(
                 "Custom",
                 style: .critical,
-                iconContent: .icon(.check, size: .xLarge, color: .blueNormal)
+                iconContent: .icon(.check, color: .blueNormal)
             )
             .padding(.vertical)
             .previewDisplayName("Custom")

--- a/Sources/Orbit/Components/ButtonLink.swift
+++ b/Sources/Orbit/Components/ButtonLink.swift
@@ -26,7 +26,7 @@ public struct ButtonLink: View {
             },
             label: {
                 HStack(spacing: .xSmall) {
-                    Icon(iconContent)
+                    Icon(iconContent, size: iconSize)
                     
                     Text(
                         label,
@@ -40,6 +40,14 @@ public struct ButtonLink: View {
             }
         )
         .buttonStyle(OrbitStyle(style: style, size: size))
+    }
+    
+    var iconSize: Icon.Size {
+        switch size {
+            case .default:          return .normal
+            case .button:           return .large
+            case .buttonSmall:      return .small
+        }
     }
 }
 

--- a/Sources/Orbit/Components/Card.swift
+++ b/Sources/Orbit/Components/Card.swift
@@ -73,7 +73,14 @@ public struct Card<Content: View>: View {
         if isHeaderEmpty == false {
             HStack(alignment: .firstTextBaseline, spacing: .small) {
 
-                Label(title, description: description, iconContent: iconContent, titleStyle: titleStyle)
+                Label(
+                    title,
+                    description: description,
+                    iconContent: iconContent,
+                    titleStyle: titleStyle,
+                    iconSpacing: .small,
+                    descriptionSpacing: .xxSmall
+                )
 
                 if case .expanding = width {
                     Spacer(minLength: .xxxSmall)
@@ -234,7 +241,7 @@ public extension Card {
     ) {
         self.title = title
         self.description = description
-        self.iconContent = .icon(icon, size: .label(titleStyle))
+        self.iconContent = .icon(icon)
         self.action = action
         self.headerSpacing = headerSpacing
         self.borderStyle = borderStyle

--- a/Sources/Orbit/Components/Card.swift
+++ b/Sources/Orbit/Components/Card.swift
@@ -78,7 +78,7 @@ public struct Card<Content: View>: View {
                     description: description,
                     iconContent: iconContent,
                     titleStyle: titleStyle,
-                    iconSpacing: .small,
+                    iconSpacing: .xSmall,
                     descriptionSpacing: .xxSmall
                 )
 
@@ -468,7 +468,8 @@ struct CardPreviews: PreviewProvider {
     
     static var listChoiceGroupsBorderless: some View {
         Card(
-            "ListChoice group title",
+            "Card with ListChoices",
+            headerSpacing: .xSmall,
             borderStyle: .none,
             backgroundColor: .clear,
             contentLayout: .fill

--- a/Sources/Orbit/Components/ChoiceTile.swift
+++ b/Sources/Orbit/Components/ChoiceTile.swift
@@ -101,6 +101,7 @@ public struct ChoiceTile<Content: View>: View {
     let badge: String
     let badgeOverlay: String
     let iconContent: Icon.Content
+    let illustration: Illustration.Image
     let indicator: ChoiceTileIndicator
     let titleStyle: Label.TitleStyle
     let isSelected: Bool
@@ -143,8 +144,13 @@ public struct ChoiceTile<Content: View>: View {
                     }
                 case .center:
                     VStack(spacing: .xxSmall) {
-                        Icon(iconContent)
-                            .padding(.bottom, .xxxSmall)
+                        if illustration == .none {
+                            Icon(iconContent, size: .label(titleStyle))
+                                .padding(.bottom, .xxxSmall)
+                        } else {
+                            Illustration(illustration, layout: .resizeable)
+                                .frame(height: .xxLarge)
+                        }
                         centeredHeading
                         Text(description, color: .inkLight, alignment: .center)
                         Badge(badge, style: .neutral)
@@ -212,6 +218,7 @@ public extension ChoiceTile {
         _ title: String = "",
         description: String = "",
         iconContent: Icon.Content,
+        illustration: Illustration.Image = .none,
         badge: String = "",
         badgeOverlay: String = "",
         indicator: ChoiceTileIndicator = .radio,
@@ -226,6 +233,7 @@ public extension ChoiceTile {
         self.title = title
         self.description = description
         self.iconContent = iconContent
+        self.illustration = illustration
         self.badge = badge
         self.badgeOverlay = badgeOverlay
         self.indicator = indicator
@@ -243,6 +251,7 @@ public extension ChoiceTile {
         _ title: String = "",
         description: String = "",
         icon: Icon.Symbol = .none,
+        illustration: Illustration.Image = .none,
         badge: String = "",
         badgeOverlay: String = "",
         indicator: ChoiceTileIndicator = .radio,
@@ -257,7 +266,8 @@ public extension ChoiceTile {
         self.init(
             title,
             description: description,
-            iconContent: .icon(icon, size: .label(titleStyle)),
+            iconContent: .icon(icon),
+            illustration: illustration,
             badge: badge,
             badgeOverlay: badgeOverlay,
             indicator: indicator,
@@ -325,7 +335,7 @@ struct ChoiceTilePreviews: PreviewProvider {
         ChoiceTile(
             "Title",
             description: "Description",
-            iconContent: .illustration(.priorityBoarding, size: .custom(90)),
+            illustration: .priorityBoarding,
             badge: "Included",
             badgeOverlay: "Recommended",
             message: .help("Message"),
@@ -401,7 +411,7 @@ struct ChoiceTilePreviews: PreviewProvider {
         VStack(spacing: .large) {
             HStack(alignment: .top, spacing: .medium) {
                 VStack(alignment: .leading, spacing: .medium) {
-                    ChoiceTile("Label", description: "Unchecked Radio", iconContent: .countryFlag("cz", size: .large), message: .help("Helpful message")) {}
+                    ChoiceTile("Label", description: "Unchecked Radio", iconContent: .countryFlag("cz"), message: .help("Helpful message")) {}
 
                     ChoiceTile("Label", indicator: .checkbox, isError: true) {
                         customContentPlaceholder
@@ -445,7 +455,7 @@ struct ChoiceTilePreviews: PreviewProvider {
         VStack(spacing: .large) {
             HStack(alignment: .top, spacing: .medium) {
                 VStack(alignment: .leading, spacing: .medium) {
-                    ChoiceTile("Label", description: "Checked Radio", iconContent: .countryFlag("cz", size: .large), message: .help("Helpful message"), alignment: .center) {}
+                    ChoiceTile("Label", description: "Checked Radio", iconContent: .countryFlag("cz"), message: .help("Helpful message"), alignment: .center) {}
 
                     ChoiceTile("Label", description: "Unchecked Checkbox", indicator: .checkbox, message: .help("Helpful message"), alignment: .center) {}
                 }

--- a/Sources/Orbit/Components/CountryFlag.swift
+++ b/Sources/Orbit/Components/CountryFlag.swift
@@ -21,7 +21,7 @@ public struct CountryFlag: View {
                 clipShape.strokeBorder(border.color, lineWidth: BorderWidth.hairline)
                     .blendMode(.darken)
             )
-            .padding(Icon.averagePadding)
+            .padding(Icon.averagePadding / 2)
             .frame(width: size.value)
             .fixedSize()
     }

--- a/Sources/Orbit/Components/Heading.swift
+++ b/Sources/Orbit/Components/Heading.swift
@@ -107,6 +107,13 @@ public extension Heading {
                 case .title6:           return Text.Size.small.lineHeight
             }
         }
+        
+        public var iconSize: CGFloat {
+            switch self {
+                case .title4:           return 22
+                default:                return lineHeight
+            }
+        }
 
         public var weight: Font.Weight {
             switch self {
@@ -159,9 +166,6 @@ struct HeadingPreviews: PreviewProvider {
 
             VStack(alignment: .leading, spacing: .xSmall) {
                 Label("Display title, but very very very very very very very long", icon: .circle, titleStyle: .display)
-                
-                Label("Display title, but very very very very very very very long", icon: .circle, titleStyle: .display)
-                
                 Label("Display subtitle, also very very very very very long", icon: .email, titleStyle: .displaySubtitle)
                 Separator()
                 Label("Title 1, also very very very very very very very verylong", icon: .circle, titleStyle: .title1)

--- a/Sources/Orbit/Components/Icon.swift
+++ b/Sources/Orbit/Components/Icon.swift
@@ -49,7 +49,7 @@ public extension Icon {
     }
     
     /// Creates Orbit Icon component for provided icon symbol.
-    init(_ symbol: Icon.Symbol, size: Size = .normal, color: Color? = .inkLighter) {
+    init(_ symbol: Icon.Symbol, size: Size = .normal, color: Color? = .inkNormal) {
         self.init(.icon(symbol, size: size, color: color))
     }
 }
@@ -145,13 +145,13 @@ struct IconPreviews: PreviewProvider {
                 Icon(.flightNomad)
                 Icon(.flightNomad, size: .small)
             }
-
+            
             HStack {
-                Icon(.informationCircle, size: .xLarge, color: .inkNormal)
-                Icon(.informationCircle, color: .inkNormal)
-                Icon(.informationCircle, size: .small, color: .inkNormal)
+                Icon(.informationCircle, size: .xLarge, color: .inkLighter)
+                Icon(.informationCircle, color: .inkLighter)
+                Icon(.informationCircle, size: .small, color: .inkLighter)
             }
-
+            
             HStack {
                 Icon(.grid, size: .xLarge, color: nil)
                 Icon(.grid)

--- a/Sources/Orbit/Components/Icon.swift
+++ b/Sources/Orbit/Components/Icon.swift
@@ -9,28 +9,27 @@ import SwiftUI
 public struct Icon: View {
 
     public static let averagePadding: CGFloat = .xxxSmall
-    let content: Icon.Content
+    
+    let content: Content
+    let size: Size
 
     public var body: some View {
         if content.isEmpty {
             EmptyView()
         } else {
             switch content {
-                case .icon(let symbol, let size, let color):
+                case .icon(let symbol, let color):
                     SwiftUI.Text(verbatim: symbol.value)
                         .foregroundColor(color)
                         .font(.orbitIcon(size: size.value))
-                case .image(let image, let size, let mode):
+                case .image(let image, let mode):
                     image
                         .resizable()
                         .aspectRatio(contentMode: mode)
                         .frame(width: size.value, height: size.value)
-                case .illustration(let illlustration, let size):
-                    Illustration(illlustration, layout: .resizeable)
-                        .frame(width: size.value, height: size.value)
-                case .countryFlag(let countryCode, let size):
+                case .countryFlag(let countryCode):
                     CountryFlag(countryCode, size: size)
-                case .sfSymbol(let systemName, let size):
+                case .sfSymbol(let systemName):
                     Image(systemName: systemName)
                         .font(.system(size: size.value - 2 * Self.averagePadding))
                 case .none:
@@ -44,41 +43,64 @@ public struct Icon: View {
 public extension Icon {
     
     /// Creates Orbit Icon component for provided icon content.
-    init(_ content: Icon.Content) {
+    ///
+    /// Color can be overriden using `foregroundColor` modifier when content color is set to `nil`.
+    init(_ content: Icon.Content, size: Size = .normal) {
         self.content = content
+        self.size = size
     }
     
     /// Creates Orbit Icon component for provided icon symbol.
     init(_ symbol: Icon.Symbol, size: Size = .normal, color: Color? = .inkNormal) {
-        self.init(.icon(symbol, size: size, color: color))
+        self.content = .icon(symbol, color: color)
+        self.size = size
+    }
+    
+    /// Creates Orbit Icon component for provided Image.
+    init(image: Image, size: Size = .normal) {
+        self.content = .image(image)
+        self.size = size
+    }
+    
+    /// Creates Orbit Icon component for provided country code.
+    init(countryCode: String, size: Size = .normal) {
+        self.content = .countryFlag(countryCode)
+        self.size = size
+    }
+    
+    /// Creates Orbit Icon component for provided SF Symbol.
+    ///
+    /// Color is configurable using `foregroundColor` modifier.
+    init(sfSymbol: String, size: Size = .normal) {
+        self.content = .sfSymbol(sfSymbol)
+        self.size = size
     }
 }
 
 // MARK: - Types
 public extension Icon {
 
-    /// Defines content of an Icon.
+    /// Defines content of an Icon for use in other components.
+    ///
+    /// Icon size is determined by enclosing component.
     enum Content: Equatable {
         case none
-        /// Orbit icon symbol with size and optional overrideable color.
-        case icon(Symbol, size: Size = .normal, color: Color? = nil)
-        /// Icon using custom Image.
-        case image(Image, size: Size = .normal, mode: ContentMode = .fit)
-        /// Orbit illustration.
-        case illustration(Illustration.Image, size: Size = .xLarge)
+        /// Orbit icon symbol with overridable color.
+        case icon(Symbol, color: Color? = nil)
+        /// Icon using custom Image with overridable size.
+        case image(Image, mode: ContentMode = .fit)
         /// Orbit CountryFlag.
-        case countryFlag(String, size: Size = .normal)
-        /// SwiftUI SF Symbol.
-        case sfSymbol(String, size: Size = .normal)
+        case countryFlag(String)
+        /// SwiftUI SF Symbol with overridable color.
+        case sfSymbol(String)
         
         public var isEmpty: Bool {
             switch self {
                 case .none:                             return true
-                case .icon(let symbol, _, _):           return symbol == .none
-                case .illustration(let image, _):       return image == .none
+                case .icon(let symbol, _):              return symbol == .none
                 case .image:                            return false
-                case .countryFlag(let countryCode, _):  return countryCode.isEmpty
-                case .sfSymbol(let systemName, _):      return systemName.isEmpty
+                case .countryFlag(let countryCode):     return countryCode.isEmpty
+                case .sfSymbol(let sfSymbol):           return sfSymbol.isEmpty
             }
         }
     }
@@ -94,7 +116,7 @@ public extension Icon {
         case xLarge
         /// Size based on Font size.
         case fontSize(CGFloat)
-        /// Size based on `Label.Title` style.
+        /// Size based on `Label` title style.
         case label(Label.TitleStyle)
         /// Custom size
         case custom(CGFloat)
@@ -106,9 +128,7 @@ public extension Icon {
                 case .large:                            return 24
                 case .xLarge:                           return 28
                 case .fontSize(let size):               return size + 1
-                case .label(.heading(let style, _)):    return style.lineHeight
-                case .label(.text(let style, _, _)):    return style.lineHeight
-                case .label(let style):                 return style.size + 1
+                case .label(let style):                 return style.iconSize
                 case .custom(let size):                 return size
             }
         }
@@ -162,17 +182,16 @@ struct IconPreviews: PreviewProvider {
             Separator()
             
             HStack {
-                Icon(.image(.orbit(.facebook)))
-                Icon(.countryFlag("cz", size: .normal))
-                Icon(.illustration(.womanWithPhone, size: .normal))
+                Icon(image: .orbit(.facebook))
+                Icon(countryCode: "cz", size: .large)
             }
             
             HStack(spacing: .xxSmall) {
-                Icon(.sfSymbol("info.circle.fill", size: .normal))
+                Icon(sfSymbol: "info.circle.fill", size: .normal)
                     .foregroundColor(.greenNormal)
                 Icon(.informationCircle, size: .normal, color: nil)
                     .foregroundColor(.greenNormal)
-                Icon(.sfSymbol("info.circle.fill", size: .xLarge))
+                Icon(sfSymbol: "info.circle.fill", size: .xLarge)
                     .foregroundColor(.greenNormal)
                 Icon(.informationCircle, size: .xLarge, color: nil)
                     .foregroundColor(.greenNormal)

--- a/Sources/Orbit/Components/InputField.swift
+++ b/Sources/Orbit/Components/InputField.swift
@@ -87,8 +87,8 @@ public struct InputField: View {
     
     @ViewBuilder var clearButton: some View {
         if value.isEmpty == false, state != .disabled {
-            Image(systemName: "multiply.circle.fill")
-                .foregroundColor(.cloudDarker)
+            Icon(sfSymbol: "multiply.circle.fill")
+                .foregroundColor(.inkLighter)
                 .padding(.small)
                 .contentShape(Rectangle())
                 .onTapGesture {

--- a/Sources/Orbit/Components/InputField.swift
+++ b/Sources/Orbit/Components/InputField.swift
@@ -191,7 +191,7 @@ struct InputFieldPreviews: PreviewProvider {
         )
         InputField(value: .constant("InputField with no label"))
         standalone
-        InputField(value: .constant("InputField with CountryFlag prefix"), prefix: .countryFlag("us", size: .normal))
+        InputField(value: .constant("InputField with CountryFlag prefix"), prefix: .countryFlag("us"))
     }
 
     static var snapshots: some View {

--- a/Sources/Orbit/Components/List.swift
+++ b/Sources/Orbit/Components/List.swift
@@ -51,20 +51,20 @@ struct ListPreviews: PreviewProvider {
 
     static var standalone: some View {
         List {
-            ListItem("This is just a line", iconContent: .icon(.airplaneDown, size: .small, color: .blue))
+            ListItem("This is just a line", iconContent: .icon(.airplaneDown, color: .blue))
             ListItem("This is just a line")
             ListItem("This is just a line", icon: .none)
-            ListItem("This is just a line", iconContent: .icon(.baggageSet, size: .small))
+            ListItem("This is just a line", iconContent: .icon(.baggageSet))
         }
     }
 
     static var snapshots: some View {
         Group {
             List {
-                ListItem("This is just a normal line", iconContent: .icon(.airplaneDown, size: .small, color: .green))
-                ListItem("This is just a normal line", iconContent: .icon(.chat, size: .small, color: .inkNormal))
-                ListItem("This is just a normal line", iconContent: .icon(.accountCircle, size: .small, color: .orange))
-                ListItem("This is just a normal line", iconContent: .icon(.document, size: .small, color: .blue))
+                ListItem("This is just a normal line", iconContent: .icon(.airplaneDown, color: .green))
+                ListItem("This is just a normal line", iconContent: .icon(.chat, color: .inkNormal))
+                ListItem("This is just a normal line", iconContent: .icon(.accountCircle, color: .orange))
+                ListItem("This is just a normal line", iconContent: .icon(.document, color: .blue))
                 ListItem("This is just a normal line", icon: .none)
             }
             .padding()

--- a/Sources/Orbit/Components/ListChoice.swift
+++ b/Sources/Orbit/Components/ListChoice.swift
@@ -74,6 +74,7 @@ public struct ListChoice<Content: View>: View {
             iconContent: icon,
             titleStyle: .text(weight: .medium),
             descriptionStyle: .custom(.small),
+            iconSpacing: .xSmall,
             descriptionSpacing: .xxxSmall
         )
         .padding(.vertical, .small)

--- a/Sources/Orbit/Components/ListChoice.swift
+++ b/Sources/Orbit/Components/ListChoice.swift
@@ -85,7 +85,7 @@ public struct ListChoice<Content: View>: View {
             case .none:
                 EmptyView()
             case .disclosure(let color):
-                Icon(.chevronRight, size: .large, color: color)
+                Icon(.chevronRight, color: color)
                     .padding(.leading, -.xSmall)
             case .button(let type):
                 disclosureButton(type: type)
@@ -320,7 +320,7 @@ struct ListChoicePreviews: PreviewProvider {
             ListChoice(title, description: description, disclosure: .none)
             ListChoice(title, description: "No Separator", disclosure: .none, showSeparator: false)
             ListChoice(title, icon: .airplane, disclosure: .none)
-            ListChoice(title, icon: .icon(.airplane, size: .xLarge, color: .blueNormal), disclosure: .none)
+            ListChoice(title, icon: .icon(.airplane, color: .blueNormal), disclosure: .none)
             ListChoice(title, description: description, icon: .countryFlag("cs"), disclosure: .none)
             ListChoice(title, description: description, icon: .grid, value: value, disclosure: .none)
             ListChoice(title, description: description, disclosure: .none) {
@@ -400,7 +400,7 @@ struct ListChoicePreviews: PreviewProvider {
                 .background(Color.white)
             ListChoice(title, icon: .airplane, disclosure: .none)
                 .background(Color.white)
-            ListChoice(title, icon: .icon(.airplane, size: .large, color: .inkLighter), disclosure: .none)
+            ListChoice(title, icon: .icon(.airplane, color: .inkLighter), disclosure: .none)
                 .background(Color.white)
             ListChoice(title, description: description, icon: .airplane, disclosure: .none)
                 .background(Color.white)

--- a/Sources/Orbit/Components/ListItem.swift
+++ b/Sources/Orbit/Components/ListItem.swift
@@ -18,7 +18,7 @@ public struct ListItem: View {
 
     public var body: some View {
         HStack(alignment: .firstTextBaseline, spacing: spacing) {
-            Icon(iconContent)
+            Icon(iconContent, size: .label(.text(size)))
                 .alignmentGuide(.firstTextBaseline) { size in
                     self.size.value * Text.firstBaselineRatio + size.height / 2
                 }
@@ -27,17 +27,6 @@ public struct ListItem: View {
                 })
 
             Text(text, size: size, color: style.textColor, linkColor: linkColor, linkAction: linkAction)
-        }
-    }
-
-    var iconSize: Icon.Size? {
-        switch iconContent {
-            case .none:                                 return nil
-            case .icon(_, let size, _):                 return size
-            case .image(_, let size, _):                return size
-            case .illustration(_, let size):            return size
-            case .countryFlag(_, let size):             return size
-            case .sfSymbol(_, let size):                return size
         }
     }
 }
@@ -76,7 +65,7 @@ public extension ListItem {
     ) {
         self.init(
             text,
-            iconContent: .icon(icon, size: .small, color: style.textColor.value),
+            iconContent: .icon(icon, color: style.textColor.value),
             size: size,
             spacing: spacing,
             style: style,
@@ -118,7 +107,7 @@ struct ListItemPreviews: PreviewProvider {
             List {
                 ListItem(
                     "ListItem",
-                    iconContent: .icon(.airplane, size: .small),
+                    icon: .airplane,
                     size: .small,
                     style: .secondary
                 )
@@ -154,7 +143,7 @@ struct ListItemPreviews: PreviewProvider {
             ListItem(#"ListItem containing <a href="link">TextLink</a> or <a href="link">Two</a>"#)
             ListItem(#"ListItem containing <a href="link">TextLink</a> or <a href="link">Two</a>"#, size: .small, style: .secondary, linkColor: .redNormal)
             ListItem(#"ListItem containing <a href="link">TextLink</a> or <a href="link">Two</a>"#, style: .custom(textColor: .greenNormal))
-            ListItem(#"ListItem containing <a href="link">TextLink</a> or <a href="link">Two</a>"#, iconContent: .icon(.circleSmall, size: .small, color: .inkNormal), style: .custom(textColor: .greenNormal))
+            ListItem(#"ListItem containing <a href="link">TextLink</a> or <a href="link">Two</a>"#, iconContent: .icon(.circleSmall, color: .inkNormal), style: .custom(textColor: .greenNormal))
         }
         .padding()
         .previewDisplayName("Snapshots - Links")
@@ -162,8 +151,8 @@ struct ListItemPreviews: PreviewProvider {
     
     static var snapshotsCustom: some View {
         List {
-            ListItem("ListItem with custom icon", iconContent: .icon(.check, size: .small, color: .greenNormal))
-            ListItem("ListItem with custom icon", iconContent: .icon(.check, size: .small))
+            ListItem("ListItem with custom icon", iconContent: .icon(.check, color: .greenNormal))
+            ListItem("ListItem with custom icon", iconContent: .icon(.check))
             ListItem("ListItem with custom icon", icon: .check)
             ListItem("ListItem with custom icon", icon: .check, style: .custom(textColor: .blueDark))
             ListItem("ListItem with no icon", icon: .none)

--- a/Sources/Orbit/Components/Select.swift
+++ b/Sources/Orbit/Components/Select.swift
@@ -65,7 +65,7 @@ public extension Select {
         prefix: Icon.Content = .none,
         value: String?,
         placeholder: String = "",
-        suffix: Icon.Content = .icon(.chevronDown, size: .large),
+        suffix: Icon.Content = .icon(.chevronDown),
         state: InputState = .default,
         message: MessageType = .none,
         action: @escaping () -> Void = {}
@@ -103,7 +103,8 @@ struct SelectPreviews: PreviewProvider {
             Select("", prefix: .icon(.airplane), value: nil, placeholder: "Please select")
             Select("Label (Empty Value)", prefix: .icon(.airplane), value: "")
             Select("Label (No Value)", prefix: .icon(.airplane), value: nil, placeholder: "Please select")
-            Select("Label", prefix: .icon(.airplane), value: "Value")
+            Select("Label", prefix: .icon(.phone), value: "Value")
+            Select("Label", prefix: .countryFlag("us"), value: "Value")
         }
         .padding(.vertical)
         .previewDisplayName("Select")

--- a/Sources/Orbit/Components/SocialButton.swift
+++ b/Sources/Orbit/Components/SocialButton.swift
@@ -31,7 +31,7 @@ public struct SocialButton: View {
 
                     Spacer(minLength: 0)
 
-                    Icon(.chevronRight, color: nil)
+                    Icon(.chevronRight, size: .large, color: nil)
                 }
             }
         )

--- a/Sources/Orbit/Components/Text.swift
+++ b/Sources/Orbit/Components/Text.swift
@@ -177,6 +177,13 @@ public extension Text {
                 case .custom(let size):     return size + 4
             }
         }
+        
+        public var iconSize: CGFloat {
+            switch self {
+                case .large:           return 22
+                default:                return lineHeight
+            }
+        }
     }
 
     enum Color: Equatable {

--- a/Sources/Orbit/Components/Tile.swift
+++ b/Sources/Orbit/Components/Tile.swift
@@ -109,7 +109,9 @@ public struct Tile<Content: View>: View {
                 title,
                 description: description,
                 iconContent: iconContent,
-                titleStyle: titleStyle
+                titleStyle: titleStyle,
+                iconSpacing: .small,
+                descriptionSpacing: .xxSmall
             )
             .padding(.vertical, .medium)
 

--- a/Sources/Orbit/Components/Tile.swift
+++ b/Sources/Orbit/Components/Tile.swift
@@ -224,7 +224,7 @@ public extension Tile {
     ) {
         self.title = title
         self.description = description
-        self.iconContent = .icon(icon, size: .label(titleStyle), color: iconColor)
+        self.iconContent = .icon(icon, color: iconColor)
         self.disclosure = disclosure
         self.border = border
         self.status = status

--- a/Sources/Orbit/Components/Toast.swift
+++ b/Sources/Orbit/Components/Toast.swift
@@ -64,7 +64,7 @@ public struct ToastContent: View {
         HStack {
             Label(
                 description,
-                iconContent: .icon(icon, size: .small, color: .white),
+                iconContent: .icon(icon, color: .white),
                 titleStyle: .text(weight: .regular, color: .white)
             )
             .padding(.small)

--- a/Sources/Orbit/Components/Toast.swift
+++ b/Sources/Orbit/Components/Toast.swift
@@ -80,10 +80,10 @@ public struct ToastContent: View {
             .overlay(progressIndicator, alignment: .leading)
             .clipShape(shape)
             .shadow(
-                color: Color(red: 0.09, green: 0.106, blue: 0.118, opacity: 0.15),
-                radius: 60,
+                color: .inkLight.opacity(0.5),
+                radius: 50,
                 x: 0,
-                y: 40
+                y: 25
             )
     }
     
@@ -92,7 +92,7 @@ public struct ToastContent: View {
             Color.inkLight
                 .opacity(max(0, progress * 2 - 0.5) * 0.3)
                 .clipShape(shape)
-                .frame(width: geometry.size.width * progress,  alignment: .bottomLeading)
+                .frame(width: geometry.size.width * progress, alignment: .bottomLeading)
                 .animation(ToastQueue.animationIn, value: progress)
         }
     }

--- a/Sources/Orbit/Support/Forms/InputStyle.swift
+++ b/Sources/Orbit/Support/Forms/InputStyle.swift
@@ -74,15 +74,20 @@ struct InputContent<Content: View>: View {
     }
 
     private var prefixColor: Color {
-        suffixColor
+        switch (value, state) {
+            case (_, .disabled):        return .cloudDarkerActive
+            case (.none, _):            return .inkNormal
+            case (_, .modified):        return .blueDark
+            default:                    return .inkNormal
+        }
     }
 
     private var suffixColor: Color {
         switch (value, state) {
             case (_, .disabled):        return .cloudDarkerActive
-            case (.none, _):            return .inkLighter
+            case (.none, _):            return .inkLight
             case (_, .modified):        return .blueDark
-            default:                    return .inkLighter
+            default:                    return .inkLight
         }
     }
 

--- a/Sources/Orbit/Support/Forms/InputStyle.swift
+++ b/Sources/Orbit/Support/Forms/InputStyle.swift
@@ -36,7 +36,7 @@ struct InputContent<Content: View>: View {
     
     var body: some View {
         HStack(spacing: 0) {
-            Icon(prefix)
+            Icon(prefix, size: .large)
                 .foregroundColor(prefixColor)
                 .padding(.horizontal, .xSmall)
 
@@ -46,7 +46,7 @@ struct InputContent<Content: View>: View {
 
             Spacer(minLength: 0)
 
-            Icon(suffix)
+            Icon(suffix, size: .large)
                 .foregroundColor(suffixColor)
                 .padding(.horizontal, .xSmall)
                 .contentShape(Rectangle())

--- a/Sources/Orbit/Support/Views/Label.swift
+++ b/Sources/Orbit/Support/Views/Label.swift
@@ -18,7 +18,7 @@ public struct Label: View {
     public var body: some View {
         if isEmpty == false {
             HStack(alignment: .firstTextBaseline, spacing: iconSpacing) {
-                Icon(iconContent)
+                Icon(iconContent, size: .label(titleStyle))
                     .alignmentGuide(.firstTextBaseline) { size in
                         self.titleStyle.size * Text.firstBaselineRatio + size.height / 2
                     }
@@ -97,7 +97,7 @@ public extension Label {
         self.init(
             title: title,
             description: description,
-            iconContent: .icon(icon, size: .label(titleStyle), color: titleStyle.color),
+            iconContent: .icon(icon, color: titleStyle.color),
             titleStyle: titleStyle,
             descriptionStyle: descriptionStyle,
             iconSpacing: iconSpacing,
@@ -107,7 +107,7 @@ public extension Label {
     }
 }
 
-// MARK: - Inits
+// MARK: - Types
 public extension Label {
 
     enum TitleStyle {
@@ -128,6 +128,13 @@ public extension Label {
             switch self {
                 case .heading(let style, _):            return style.size
                 case .text(let size, _, _):             return size.value
+            }
+        }
+        
+        var iconSize: CGFloat {
+            switch self {
+                case .heading(let style, _):            return style.iconSize
+                case .text(let size, _, _):             return size.iconSize
             }
         }
         

--- a/Sources/Orbit/Support/Views/Label.swift
+++ b/Sources/Orbit/Support/Views/Label.swift
@@ -22,6 +22,9 @@ public struct Label: View {
                     .alignmentGuide(.firstTextBaseline) { size in
                         self.titleStyle.size * Text.firstBaselineRatio + size.height / 2
                     }
+                    .alignmentGuide(.labelAlignment) { size in
+                        size.width + iconSpacing
+                    }
 
                 if isTextEmpty == false {
                     VStack(alignment: .leading, spacing: descriptionSpacing) {
@@ -180,6 +183,19 @@ public extension Label {
         }
     }
 }
+
+// MARK: - Alignment
+extension HorizontalAlignment {
+    
+    enum LabelAlignment: AlignmentID {
+        static func defaultValue(in context: ViewDimensions) -> CGFloat {
+            context[.leading]
+        }
+    }
+
+    static let labelAlignment = HorizontalAlignment(LabelAlignment.self)
+}
+
 
 // MARK: - Previews
 struct HeaderPreviews: PreviewProvider {


### PR DESCRIPTION
Fixes related to issues found when syncing with the kiwi.com app.

Major change - Icon.Content that is passed to various components does not contain size anymore - the component itself decides about the correct icon size. Most of the time this means icon size is derived from the surrounding text lineHeight, which is the default Orbit rule.