### PR TITLE
Run the design token update once a week on Monday

### DIFF
--- a/.github/workflows/tokens-updater.yml
+++ b/.github/workflows/tokens-updater.yml
@@ -2,7 +2,7 @@ name: Design Tokens Updater
 
 on:
   schedule:
-    - cron: '0 6 * * 1-5' # every work-day at 6:00am
+    - cron: '0 0 * * MON' # every Monday
   workflow_dispatch:
   
 env:


### PR DESCRIPTION
As we link to the most up-to-date, often sometimes WIP versions of tokens, it might be better to only update once a week.

In the last week, there was an illustration change going back and forth every day.