### PR TITLE
Support custom formatting in InputField

### DIFF
--- a/Sources/Orbit/Components/InputField.swift
+++ b/Sources/Orbit/Components/InputField.swift
@@ -417,6 +417,24 @@ struct InputFieldPreviews: PreviewProvider {
 
 struct InputFieldLivePreviews: PreviewProvider {
 
+    class UppercaseAlphabetFormatter: Formatter {
+
+        override func string(for obj: Any?) -> String? {
+            guard let string = obj as? String else { return nil }
+
+            return string.uppercased()
+        }
+
+        override func getObjectValue(
+            _ obj: AutoreleasingUnsafeMutablePointer<AnyObject?>?,
+            for string: String,
+            errorDescription error: AutoreleasingUnsafeMutablePointer<NSString?>?
+        ) -> Bool {
+            obj?.pointee = string.lowercased() as AnyObject
+            return true
+        }
+    }
+
     static var previews: some View {
         PreviewWrapper()
         securedWrapper
@@ -446,6 +464,19 @@ struct InputFieldLivePreviews: PreviewProvider {
 
                 Text("Some text, but also very long and multi-line to test that it works.")
 
+                Spacer()
+
+                VStack(alignment: .leading, spacing: .medium) {
+                    Text("InputField uppercasing the input, but not changing projected value:")
+                    
+                    InputField(
+                        value: $value,
+                        placeholder: "Use Formatter subclass",
+                        formatter: UppercaseAlphabetFormatter()
+                    )
+                }
+
+                Spacer()
                 Spacer()
 
                 Button("Change") {


### PR DESCRIPTION
It's a draft implementation of how we might expose SwiftUI formatting API to end users.

Alternative to https://github.com/kiwicom/orbit-swiftui/pull/145

The proposal based on enum which has huge limitation.  Some API methods are uses @available attributes,  but as far as I know `enum case` doesn't support it which means
```
enum Mode {
case formatter(formatter: Formatter) // Formatter is available from iOS13
case formatStyle(style: FormatStyle) // FormatStyle is available from iOS15
```

will not compile. Do we have other options with an enum to expose different types? 

I will prepare another MR where will try to avoid such limitation with a `factoryMethod`