### PR TITLE
Release updates

### DIFF
--- a/Sources/Orbit/Components/Alert.swift
+++ b/Sources/Orbit/Components/Alert.swift
@@ -46,7 +46,7 @@ public struct Alert<Content: View>: View {
     public var body: some View {
         HStack(alignment: .firstTextBaseline, spacing: .xSmall) {
             
-            Icon(iconContent, size: .normal)
+            Icon(content: iconContent, size: .normal)
                 .foregroundColor(status.color)
             
             VStack(alignment: .leading, spacing: .medium) {

--- a/Sources/Orbit/Components/Badge.swift
+++ b/Sources/Orbit/Components/Badge.swift
@@ -25,7 +25,7 @@ public struct Badge: View {
         if isEmpty == false {
             HStack(spacing: 0) {
                 HStack(spacing: .xxSmall) {
-                    Icon(iconContent, size: .small)
+                    Icon(content: iconContent, size: .small)
 
                     Text(
                         label,

--- a/Sources/Orbit/Components/BadgeList.swift
+++ b/Sources/Orbit/Components/BadgeList.swift
@@ -22,7 +22,7 @@ public struct BadgeList: View {
     public var body: some View {
         if isEmpty == false {
             HStack(alignment: .firstTextBaseline, spacing: Self.spacing) {
-                Icon(iconContent, size: .small)
+                Icon(content: iconContent, size: .small)
                     .foregroundColor(style.iconColor)
                     .padding(.xxSmall)
                     .background(badgeBackground)

--- a/Sources/Orbit/Components/Button.swift
+++ b/Sources/Orbit/Components/Button.swift
@@ -31,7 +31,7 @@ public struct Button: View {
                     }
 
                     HStack(alignment: .firstTextBaseline, spacing: .xSmall) {
-                        Icon(iconContent, size: iconSize)
+                        Icon(content: iconContent, size: iconSize)
                         text
                             .padding(.vertical, size.verticalPadding)
                     }
@@ -41,7 +41,7 @@ public struct Button: View {
                     TextStrut(size.textSize)
                         .padding(.vertical, size.verticalPadding)
 
-                    Icon(disclosureIconContent, size: iconSize)
+                    Icon(content: disclosureIconContent, size: iconSize)
                 }
                 .padding(.leading, leadingPadding)
                 .padding(.trailing, trailingPadding)

--- a/Sources/Orbit/Components/ButtonLink.swift
+++ b/Sources/Orbit/Components/ButtonLink.swift
@@ -25,7 +25,7 @@ public struct ButtonLink: View {
                 label: {
                     HStack(spacing: 0) {
                         HStack(alignment: .firstTextBaseline, spacing: .xSmall) {
-                            Icon(iconContent, size: iconSize)
+                            Icon(content: iconContent, size: iconSize)
 
                             Text(
                                 label,

--- a/Sources/Orbit/Components/Card.swift
+++ b/Sources/Orbit/Components/Card.swift
@@ -73,7 +73,7 @@ public struct Card<Content: View>: View {
         if isHeaderEmpty == false {
             HStack(alignment: .firstTextBaseline, spacing: 0) {
 
-                Icon(iconContent, size: .heading(titleStyle))
+                Icon(content: iconContent, size: .heading(titleStyle))
                     .padding(.trailing, .xSmall)
                 
                 VStack(alignment: .leading, spacing: .xxSmall) {

--- a/Sources/Orbit/Components/ChoiceTile.swift
+++ b/Sources/Orbit/Components/ChoiceTile.swift
@@ -80,7 +80,7 @@ public struct ChoiceTile<Content: View>: View {
                 case .default:
                     HStack(alignment: .firstTextBaseline, spacing: 0) {
                         
-                        Icon(iconContent, size: .heading(titleStyle))
+                        Icon(content: iconContent, size: .heading(titleStyle))
                             .foregroundColor(.inkNormal)
                             .padding(.trailing, .xSmall)
                         
@@ -96,7 +96,7 @@ public struct ChoiceTile<Content: View>: View {
                 case .center:
                     VStack(spacing: .xxSmall) {
                         if illustration == .none {
-                            Icon(iconContent, size: .heading(titleStyle))
+                            Icon(content: iconContent, size: .heading(titleStyle))
                                 .padding(.bottom, .xxSmall)
                         } else {
                             Illustration(illustration, layout: .resizeable)

--- a/Sources/Orbit/Components/Icon.swift
+++ b/Sources/Orbit/Components/Icon.swift
@@ -67,7 +67,7 @@ public extension Icon {
     ///
     /// - Parameters:
     ///     - content: Icon content. Can optionally include the color override.
-    init(_ content: Icon.Content, size: Size = .normal) {
+    init(content: Icon.Content, size: Size = .normal) {
         self.content = content
         self.size = size
     }
@@ -77,20 +77,26 @@ public extension Icon {
     /// - Parameters:
     ///     - color: Icon color. Can be set to `nil` and specified later using `.foregroundColor()` modifier.
     init(_ symbol: Icon.Symbol, size: Size = .normal, color: Color? = .inkNormal) {
-        self.content = .symbol(symbol, color: color)
-        self.size = size
+        self.init(
+            content: .symbol(symbol, color: color),
+            size: size
+        )
     }
     
     /// Creates Orbit Icon component for provided Image.
     init(image: Image, size: Size = .normal) {
-        self.content = .image(image)
-        self.size = size
+        self.init(
+            content: .image(image),
+            size: size
+        )
     }
     
     /// Creates Orbit Icon component for provided country code.
     init(countryCode: String, size: Size = .normal) {
-        self.content = .countryFlag(countryCode)
-        self.size = size
+        self.init(
+            content: .countryFlag(countryCode),
+            size: size
+        )
     }
     
     /// Creates Orbit Icon component for provided SF Symbol with specified color.
@@ -98,8 +104,10 @@ public extension Icon {
     /// - Parameters:
     ///     - color: SF Symbol color. Can be set to `nil` and specified later using `.foregroundColor()` modifier.
     init(sfSymbol: String, size: Size = .normal, color: Color? = .inkNormal) {
-        self.content = .sfSymbol(sfSymbol, color: color)
-        self.size = size
+        self.init(
+            content: .sfSymbol(sfSymbol, color: color),
+            size: size
+        )
     }
 }
 
@@ -373,12 +381,12 @@ struct IconPreviews: PreviewProvider {
         VStack(spacing: .small) {
             HStack(alignment: .firstTextBaseline, spacing: 0) {
                 Group {
-                    Icon(.sfSymbol(sfSymbol), size: .custom(Text.Size.xLarge.iconSize))
-                    Icon(.sfSymbol(sfSymbol), size: .fontSize(Text.Size.xLarge.value))
-                    Icon(.sfSymbol(sfSymbol), size: .label(.text(.xLarge)))
-                    Icon(.informationCircle, size: .custom(Text.Size.xLarge.iconSize))
-                    Icon(.informationCircle, size: .fontSize(Text.Size.xLarge.value))
-                    Icon(.informationCircle, size: .label(.text(.xLarge)))
+                    Icon(sfSymbol: sfSymbol, size: .custom(Text.Size.xLarge.iconSize), color: nil)
+                    Icon(sfSymbol: sfSymbol, size: .fontSize(Text.Size.xLarge.value), color: nil)
+                    Icon(sfSymbol: sfSymbol, size: .label(.text(.xLarge)), color: nil)
+                    Icon(.informationCircle, size: .custom(Text.Size.xLarge.iconSize), color: nil)
+                    Icon(.informationCircle, size: .fontSize(Text.Size.xLarge.value), color: nil)
+                    Icon(.informationCircle, size: .label(.text(.xLarge)), color: nil)
                     Text("XLarge", size: .xLarge, color: nil)
                 }
                 .foregroundColor(.blueNormal)
@@ -388,12 +396,12 @@ struct IconPreviews: PreviewProvider {
             
             HStack(alignment: .firstTextBaseline, spacing: 0) {
                 Group {
-                    Icon(.sfSymbol(sfSymbol), size: .custom(Text.Size.small.iconSize))
-                    Icon(.sfSymbol(sfSymbol), size: .fontSize(Text.Size.small.value))
-                    Icon(.sfSymbol(sfSymbol), size: .label(.text(.small)))
-                    Icon(.informationCircle, size: .custom(Text.Size.small.iconSize))
-                    Icon(.informationCircle, size: .fontSize(Text.Size.small.value))
-                    Icon(.informationCircle, size: .label(.text(.small)))
+                    Icon(sfSymbol: sfSymbol, size: .custom(Text.Size.small.iconSize), color: nil)
+                    Icon(sfSymbol: sfSymbol, size: .fontSize(Text.Size.small.value), color: nil)
+                    Icon(sfSymbol: sfSymbol, size: .label(.text(.small)), color: nil)
+                    Icon(.informationCircle, size: .custom(Text.Size.small.iconSize), color: nil)
+                    Icon(.informationCircle, size: .fontSize(Text.Size.small.value), color: nil)
+                    Icon(.informationCircle, size: .label(.text(.small)), color: nil)
                     Text("Small", size: .small, color: nil)
                 }
                 .foregroundColor(.blueNormal)
@@ -403,9 +411,9 @@ struct IconPreviews: PreviewProvider {
             
             HStack(alignment: .firstTextBaseline, spacing: 0) {
                 Group {
-                    Icon(.countryFlag("cz"), size: .xLarge)
-                    Icon(.image(.orbit(.facebook)), size: .xLarge)
-                    Icon(.sfSymbol(sfSymbol), size: .xLarge)
+                    Icon(countryCode: "cz", size: .xLarge)
+                    Icon(image: .orbit(.facebook), size: .xLarge)
+                    Icon(sfSymbol: sfSymbol, size: .xLarge, color: nil)
                     Text("Text", size: .custom(20), color: nil)
                 }
                 .foregroundColor(.blueNormal)
@@ -415,9 +423,9 @@ struct IconPreviews: PreviewProvider {
             
             HStack(alignment: .firstTextBaseline, spacing: 0) {
                 Group {
-                    Icon(.countryFlag("cz"), size: .small)
-                    Icon(.image(.orbit(.facebook)), size: .small)
-                    Icon(.sfSymbol(sfSymbol), size: .small)
+                    Icon(countryCode: "cz", size: .small)
+                    Icon(image: .orbit(.facebook), size: .small)
+                    Icon(sfSymbol: sfSymbol, size: .small, color: nil)
                     Text("Text", size: .small, color: nil)
                 }
                 .foregroundColor(.blueNormal)
@@ -437,9 +445,9 @@ struct IconPreviews: PreviewProvider {
             .background(HairlineSeparator(), alignment: .init(horizontal: .center, vertical: .firstTextBaseline))
             
             HStack(alignment: .firstTextBaseline) {
-                Icon(.grid, size: .xLarge)
-                Icon(.symbol(.grid, color: nil))
-                Icon(.symbol(.grid, color: .blueNormal), size: .small)
+                Icon(content: .grid, size: .xLarge)
+                Icon(content: .symbol(.grid, color: nil))
+                Icon(content: .symbol(.grid, color: .blueNormal), size: .small)
             }
             .foregroundColor(.blueDark)
             .background(HairlineSeparator(), alignment: .init(horizontal: .center, vertical: .firstTextBaseline))

--- a/Sources/Orbit/Components/InputField.swift
+++ b/Sources/Orbit/Components/InputField.swift
@@ -36,37 +36,35 @@ public struct InputField: View {
 
     public var body: some View {
         FormFieldWrapper(label, message: message, messageHeight: $messageHeight) {
-            VStack(alignment: .leading, spacing: .xxSmall) {
-                InputContent(
-                    prefix: prefix,
-                    suffix: suffix,
-                    state: state,
-                    message: message,
-                    isEditing: isEditing,
-                    suffixAction: suffixAction
-                ) {
-                    HStack(spacing: 0) {
-                        input
-                            .textFieldStyle(TextFieldStyle(leadingPadding: 0))
-                            .autocapitalization(autocapitalization)
-                            .disableAutocorrection(isAutocompleteEnabled == false)
-                            .textContentType(textContent)
-                            .keyboardType(keyboard)
-                            .font(.orbit(size: Text.Size.normal.value, weight: .regular))
-                            .accentColor(.blueNormal)
-                            .background(textFieldPlaceholder, alignment: .leading)
-                            .disabled(state == .disabled)
-                        if isSecure {
-                            securedSuffix
-                        } else {
-                            clearButton
-                        }
+            InputContent(
+                prefix: prefix,
+                suffix: suffix,
+                state: state,
+                message: message,
+                isEditing: isEditing,
+                suffixAction: suffixAction
+            ) {
+                HStack(spacing: 0) {
+                    input
+                        .textFieldStyle(TextFieldStyle(leadingPadding: 0))
+                        .autocapitalization(autocapitalization)
+                        .disableAutocorrection(isAutocompleteEnabled == false)
+                        .textContentType(textContent)
+                        .keyboardType(keyboard)
+                        .font(.orbit(size: Text.Size.normal.value, weight: .regular))
+                        .accentColor(.blueNormal)
+                        .background(textFieldPlaceholder, alignment: .leading)
+                        .disabled(state == .disabled)
+                    if isSecure {
+                        securedSuffix
+                    } else {
+                        clearButton
                     }
                 }
-
-                PasswordStrengthIndicator(passwordStrength: passwordStrength)
-                    .padding(.top, .xxSmall)
             }
+        } messageContent: {
+            PasswordStrengthIndicator(passwordStrength: passwordStrength)
+                .padding(.top, .xxSmall)
         }
     }
 
@@ -221,6 +219,7 @@ struct InputFieldPreviews: PreviewProvider {
         PreviewWrapper {
             standalone
             storybook
+            storybookPassword
             storybookMix
         }
         .previewLayout(.sizeThatFits)
@@ -252,6 +251,34 @@ struct InputFieldPreviews: PreviewProvider {
         }
     }
 
+    static var storybookPassword: some View {
+        VStack(spacing: .medium) {
+            InputField("Password", value: .constant("password"), isSecure: true)
+            InputField("Password", value: .constant(""), placeholder: "Input password", isSecure: true)
+            InputField(
+                "Password",
+                value: .constant("password"),
+                isSecure: true,
+                passwordStrength: .strong(title: "Strong")
+            )
+            InputField(
+                "Password",
+                value: .constant("password"),
+                isSecure: true,
+                passwordStrength: .medium(title: "Medium"),
+                message: .help("Help message")
+            )
+            InputField(
+                "Password",
+                value: .constant("password"),
+                isSecure: true,
+                passwordStrength: .weak(title: "Weak"),
+                message: .error("Error message")
+            )
+        }
+        .padding(.medium)
+    }
+
     static var storybookMix: some View {
         VStack(spacing: .medium) {
             InputField("Empty", value: .constant(""), prefix: .symbol(.grid, color: .blueDark), suffix: .symbol(.grid, color: .blueDark), placeholder: placeholder)
@@ -265,17 +292,6 @@ struct InputFieldPreviews: PreviewProvider {
                 value: .constant("Error value with a very long length to test that it works"),
                 message: .error("Error message, also very long and multi-line to test that it works.")
             ).padding(.bottom, .small)
-
-            VStack(spacing: .medium) {
-                InputField("Secured", value: .constant("password"), isSecure: true)
-                InputField("Secured", value: .constant(""), placeholder: "Input password", isSecure: true)
-                InputField(
-                    "Secured",
-                    value: .constant("password"),
-                    isSecure: true,
-                    passwordStrength: .medium(title: "Medium")
-                )
-            }
 
             HStack(spacing: .medium) {
                 InputField(value: .constant("No label"))

--- a/Sources/Orbit/Components/ListChoice.swift
+++ b/Sources/Orbit/Components/ListChoice.swift
@@ -85,7 +85,7 @@ public struct ListChoice<HeaderContent: View, Content: View>: View {
     @ViewBuilder var headerTexts: some View {
         if isHeaderEmpty == false {
             HStack(alignment: .firstTextBaseline, spacing: .xSmall) {
-                Icon(iconContent)
+                Icon(content: iconContent)
                     .foregroundColor(.inkNormal)
                 
                 if isHeaderTextEmpty == false {
@@ -105,7 +105,7 @@ public struct ListChoice<HeaderContent: View, Content: View>: View {
             case .none:
                 EmptyView()
             case .disclosure(let color):
-                Icon(.symbol(.chevronRight, color: color))
+                Icon(.chevronRight, color: color)
                     .padding(.leading, -.xSmall)
             case .button(let type):
                 disclosureButton(type: type)
@@ -463,7 +463,13 @@ struct ListChoicePreviews: PreviewProvider {
             ListChoice(title, description: description, disclosure: .radio(state: .disabled))
             ListChoice(title, icon: .airplane, disclosure: .radio(isChecked: false, state: .error))
             ListChoice(title, icon: .airplane, disclosure: .radio(isChecked: false, state: .disabled))
-            ListChoice(title, description: description, icon: .airplane, disclosure: .radio(isChecked: false)) {
+            ListChoice(
+                title,
+                description: description,
+                icon: .airplane,
+                disclosure: .radio(isChecked: false),
+                action: {}
+            ) {
                 customContentPlaceholder
             } headerContent: {
                 headerContent

--- a/Sources/Orbit/Components/NotificationBadge.swift
+++ b/Sources/Orbit/Components/NotificationBadge.swift
@@ -23,7 +23,7 @@ public struct NotificationBadge: View {
         if isEmpty == false {
             HStack(spacing: 0) {
                 HStack(spacing: .xxxSmall) {
-                    Icon(iconContent, size: .text(Self.textSize))
+                    Icon(content: iconContent, size: .text(Self.textSize))
                     
                     Text(
                         label,

--- a/Sources/Orbit/Components/Tag.swift
+++ b/Sources/Orbit/Components/Tag.swift
@@ -30,7 +30,7 @@ public struct Tag: View {
                 label: {
                     HStack(spacing: 0) {
                         HStack(alignment: .firstTextBaseline, spacing: 6) {
-                            Icon(iconContent)
+                            Icon(content: iconContent)
                             Text(label, color: nil, weight: .medium)
                                 .padding(.vertical, Self.verticalPadding)
                         }

--- a/Sources/Orbit/Components/Tile.swift
+++ b/Sources/Orbit/Components/Tile.swift
@@ -122,7 +122,7 @@ public struct Tile<Content: View>: View {
     @ViewBuilder var header: some View {
         if isHeaderEmpty == false {
             HStack(alignment: .firstTextBaseline, spacing: 0) {
-                Icon(iconContent, size: .heading(titleStyle))
+                Icon(content: iconContent, size: .heading(titleStyle))
                     .foregroundColor(.inkNormal)
                     .padding(.trailing, .xSmall)
 
@@ -157,7 +157,7 @@ public struct Tile<Content: View>: View {
             case .none, .buttonLink:
                 EmptyView()
             case .icon(let icon, _):
-                Icon(icon)
+                Icon(content: icon)
                     .foregroundColor(.inkLight)
                     .padding(.leading, .xSmall)
         }

--- a/Sources/Orbit/Support/Components/BarButton.swift
+++ b/Sources/Orbit/Support/Components/BarButton.swift
@@ -12,7 +12,7 @@ public struct BarButton: View {
                 action()
             },
             label: {
-                Icon(.symbol(symbol), size: .large)
+                Icon(symbol, size: .large)
             }
         )
         .buttonStyle(NavigateButton.OrbitStyle())

--- a/Sources/Orbit/Support/Components/Label.swift
+++ b/Sources/Orbit/Support/Components/Label.swift
@@ -30,10 +30,10 @@ public struct Label: View {
 
     @ViewBuilder var icon: some View {
         if let color = style.color {
-            Icon(iconContent, size: .label(style))
+            Icon(content: iconContent, size: .label(style))
                 .foregroundColor(color)
         } else {
-            Icon(iconContent, size: .label(style))
+            Icon(content: iconContent, size: .label(style))
         }
     }
     

--- a/Sources/Orbit/Support/Components/PasswordStrengthIndicator.swift
+++ b/Sources/Orbit/Support/Components/PasswordStrengthIndicator.swift
@@ -30,7 +30,7 @@ public struct PasswordStrengthIndicator: View {
         HStack(spacing: 0) {
             Capsule()
                 .fill(Color(uiColor))
-                .frame(width: .infinity, alignment: .leading)
+                .frame(maxWidth: .infinity, alignment: .leading)
 
             ForEach(0 ..< spacers, id: \.self) { _ in
                 Spacer()

--- a/Sources/Orbit/Support/Components/Tab.swift
+++ b/Sources/Orbit/Support/Components/Tab.swift
@@ -46,7 +46,7 @@ public struct Tab: View {
     public var body: some View {
         // FIXME: Convert to Button with .title4 style for a background touch feedback
         HStack(spacing: .xSmall) {
-            Icon(iconContent)
+            Icon(content: iconContent)
             Text(label, color: .none, weight: .medium, alignment: .center)
         }
         .padding(.horizontal, .medium)

--- a/Sources/Orbit/Support/Components/TimelineStep.swift
+++ b/Sources/Orbit/Support/Components/TimelineStep.swift
@@ -53,7 +53,7 @@ public struct TimelineStep: View {
                     .strokeBorder(Color.cloudNormalHover, lineWidth: 2)
                     .frame(width: .small, height: .small)
             case .status:
-                Icon(.symbol(style.iconSymbol, color: style.color), size: .large)
+                Icon(style.iconSymbol, size: .large, color: style.color)
         }
     }
 

--- a/Sources/Orbit/Support/Forms/FormFieldMessage.swift
+++ b/Sources/Orbit/Support/Forms/FormFieldMessage.swift
@@ -9,7 +9,7 @@ public struct FormFieldMessage: View {
     public var body: some View {
         if message.isEmpty == false {
             HStack(alignment: .firstTextBaseline, spacing: spacing) {
-                Icon(.symbol(message.icon, color: message.color), size: .small)
+                Icon(message.icon, size: .small, color: message.color)
                 Text(message.description, color: .custom(message.uiColor))
                     .alignmentGuide(.firstTextBaseline) { _ in
                         Text.Size.small.value * 1.1

--- a/Sources/Orbit/Support/Forms/FormFieldWrapper.swift
+++ b/Sources/Orbit/Support/Forms/FormFieldWrapper.swift
@@ -1,13 +1,14 @@
 import SwiftUI
 
 /// Orbit wrapper around form fields. Provides optional label and message.
-public struct FormFieldWrapper<Content: View>: View {
+public struct FormFieldWrapper<Content: View, MessageContent: View>: View {
 
     @Binding private var messageHeight: CGFloat
 
     let label: String
     let message: MessageType
     let content: () -> Content
+    let messageContent: () -> MessageContent
 
     public var body: some View {
         VStack(alignment: .leading, spacing: 0) {
@@ -17,22 +18,43 @@ public struct FormFieldWrapper<Content: View>: View {
             content()
 
             ContentHeightReader(height: $messageHeight.animation(.easeOut(duration: 0.2))) {
-                FormFieldMessage(message)
-                    .padding(.top, .xxSmall)
+                VStack(alignment: .leading, spacing: 0) {
+                    messageContent()
+
+                    FormFieldMessage(message)
+                        .padding(.top, .xxSmall)
+                }
             }
         }
     }
 
+    /// Creates Orbit wrapper around form field content including an additional custom message content.
     public init(
         _ label: String,
         message: MessageType = .none,
         messageHeight: Binding<CGFloat> = .constant(0),
-        @ViewBuilder content: @escaping () -> Content)
-    {
+        @ViewBuilder content: @escaping () -> Content,
+        @ViewBuilder messageContent: @escaping () -> MessageContent
+    ) {
         self.label = label
         self.message = message
         self._messageHeight = messageHeight
         self.content = content
+        self.messageContent = messageContent
+    }
+
+    /// Creates Orbit wrapper around form field content.
+    public init(
+        _ label: String,
+        message: MessageType = .none,
+        messageHeight: Binding<CGFloat> = .constant(0),
+        @ViewBuilder content: @escaping () -> Content
+    ) where MessageContent == EmptyView {
+        self.label = label
+        self.message = message
+        self._messageHeight = messageHeight
+        self.content = content
+        self.messageContent = { EmptyView() }
     }
 }
 

--- a/Sources/Orbit/Support/Forms/InputStyle.swift
+++ b/Sources/Orbit/Support/Forms/InputStyle.swift
@@ -51,7 +51,7 @@ struct InputContent<Content: View>: View {
     
     var body: some View {
         HStack(spacing: 0) {
-            Icon(prefix, size: .large)
+            Icon(content: prefix, size: .large)
                 .foregroundColor(prefixColor)
                 .padding(.horizontal, .xSmall)
 
@@ -82,7 +82,7 @@ struct InputContent<Content: View>: View {
     }
 
     @ViewBuilder var suffixIcon: some View {
-        Icon(suffix, size: .large)
+        Icon(content: suffix, size: .large)
             .foregroundColor(suffixColor)
             .padding(.horizontal, .xSmall)
             .contentShape(Rectangle())

--- a/Sources/Orbit/Support/Storybook/Foundation/StorybookIcons.swift
+++ b/Sources/Orbit/Support/Storybook/Foundation/StorybookIcons.swift
@@ -23,7 +23,7 @@ struct StorybookIcons {
 
     @ViewBuilder static func icon(_ icon: Icon.Symbol) -> some View {
         VStack(spacing: .xxSmall) {
-            Icon(.symbol(icon))
+            Icon(icon)
                 .foregroundColor(.inkNormal)
             Text(String(describing: icon).titleCased, size: .custom(10), color: .inkLight, isSelectable: true)
             Text(String(icon.value.unicodeCodePoint), size: .custom(10), isSelectable: true)

--- a/Sources/Orbit/Support/Storybook/Storybook+Items.swift
+++ b/Sources/Orbit/Support/Storybook/Storybook+Items.swift
@@ -156,6 +156,7 @@ extension Storybook {
                 case (.icon, 1):                IconPreviews.storybookMix
                 case (.illustration, _):        IllustrationPreviews.storybook
                 case (.inputField, 0):          InputFieldPreviews.storybook
+                case (.inputField, 2):          InputFieldPreviews.storybookPassword
                 case (.inputField, 3):          InputFieldPreviews.storybookMix
                 case (.keyValue, _):            KeyValuePreviews.storybook
                 case (.list, 0):                ListPreviews.storybook


### PR DESCRIPTION
Batch of fixes for upcoming release.

The `Icon` init with a `.symbol` becomes the default, preferred one, for the standalone `Icon` component to better separate the default inkNormal color for the component vs nil color for the content model type.