### PR TITLE
Update component accessibility

### DIFF
--- a/Sources/Orbit/Components/ChoiceTile.swift
+++ b/Sources/Orbit/Components/ChoiceTile.swift
@@ -69,8 +69,13 @@ public struct ChoiceTile<Content: View>: View {
             }
         )
         .buttonStyle(TileButtonStyle(isSelected: isSelected, status: errorShouldHighlightBorder ? .critical : nil))
-        .accessibility(addTraits: isSelected ? .isSelected : [])
         .overlay(badgeOverlayView, alignment: .top)
+        .accessibilityElement(children: .ignore)
+        .accessibility(label: .init(title))
+        .accessibility(value: .init(badgeOverlay.isEmpty ?  badge : badgeOverlay))
+        .accessibility(hint: .init(message.description.isEmpty ? description : message.description))
+        .accessibility(addTraits: .isButton)
+        .accessibility(addTraits: isSelected ? .isSelected : [])
     }
     
     @ViewBuilder var header: some View {
@@ -273,7 +278,7 @@ struct ChoiceTilePreviews: PreviewProvider {
         PreviewWrapper {
             standalone
             standaloneCentered
-//            sizing
+            sizing
 
             storybook
             storybookCentered

--- a/Sources/Orbit/Components/InputField.swift
+++ b/Sources/Orbit/Components/InputField.swift
@@ -67,10 +67,10 @@ public struct InputField: View {
                 .padding(.top, .xxSmall)
         }
         .accessibilityElement(children: .ignore)
-        .accessibility(label: SwiftUI.Text(label))
-        .accessibility(value: SwiftUI.Text(value))
-        .accessibility(hint: SwiftUI.Text(placeholder))
-        .accessibility(addTraits: state != .disabled ? .isButton : [])
+        .accessibility(label: .init(label))
+        .accessibility(value: .init(value))
+        .accessibility(hint: .init(message.description.isEmpty ? placeholder : message.description))
+        .accessibility(addTraits: .isButton)
     }
 
     @ViewBuilder var input: some View {

--- a/Sources/Orbit/Components/KeyValue.swift
+++ b/Sources/Orbit/Components/KeyValue.swift
@@ -18,6 +18,10 @@ public struct KeyValue: View {
         KeyValueField(key, size: size, alignment: alignment) {
             Text(value, size: size.valueSize, weight: .medium, alignment: .init(alignment), isSelectable: true)
         }
+        .accessibilityElement(children: .ignore)
+        .accessibility(label: .init(key))
+        .accessibility(value: .init(value))
+        .accessibility(addTraits: .isStaticText)
     }
 }
 

--- a/Sources/Orbit/Components/ListChoice.swift
+++ b/Sources/Orbit/Components/ListChoice.swift
@@ -33,6 +33,7 @@ public struct ListChoice<HeaderContent: View, Content: View>: View {
     let title: String
     let description: String
     let iconContent: Icon.Content
+    let value: String
     let disclosure: ListChoiceDisclosure
     let showSeparator: Bool
     let action: () -> Void
@@ -40,35 +41,40 @@ public struct ListChoice<HeaderContent: View, Content: View>: View {
     let headerContent: () -> HeaderContent
 
     public var body: some View {
-        SwiftUI.Button(
-            action: {
-                HapticsProvider.sendHapticFeedback(.light(0.5))
-                action()
-            },
-            label: {
-                buttonContent
-            }
-        )
-        .buttonStyle(ListChoiceButtonStyle())
-        .accessibility(addTraits: accessibilityTraitsToAdd)
+        if isEmpty == false {
+            SwiftUI.Button(
+                action: {
+                    HapticsProvider.sendHapticFeedback(.light(0.5))
+                    action()
+                },
+                label: {
+                    buttonContent
+                }
+            )
+            .buttonStyle(ListChoiceButtonStyle())
+            .accessibilityElement(children: .ignore)
+            .accessibility(label: .init(title))
+            .accessibility(value: .init(value))
+            .accessibility(hint: .init(description))
+            .accessibility(addTraits: .isButton)
+            .accessibility(addTraits: accessibilityTraitsToAdd)
+        }
     }
 
     @ViewBuilder var buttonContent: some View {
-        if isEmpty == false {
-            HStack(spacing: 0) {
-                VStack(alignment: .leading, spacing: 0) {
-                    header
-                    content()
-                }
-
-                disclosureView
-                    .padding(.horizontal, .medium)
-                    .padding(.vertical, .small)
-                    .disabled(true)
+        HStack(spacing: 0) {
+            VStack(alignment: .leading, spacing: 0) {
+                header
+                content()
             }
-            .frame(maxWidth: Layout.readableMaxWidth, alignment: .leading)
-            .overlay(separator, alignment: .bottom)
+
+            disclosureView
+                .padding(.horizontal, .medium)
+                .padding(.vertical, .small)
+                .disabled(true)
         }
+        .frame(maxWidth: Layout.readableMaxWidth, alignment: .leading)
+        .overlay(separator, alignment: .bottom)
     }
     
     @ViewBuilder var header: some View {
@@ -86,6 +92,7 @@ public struct ListChoice<HeaderContent: View, Content: View>: View {
                 headerContent()
                     .padding(.leading, isHeaderEmpty ? .medium : 0)
                     .padding(.trailing, disclosure == .none ? .medium : 0)
+                    .accessibility(.listChoiceValue)
             }
         }
     }
@@ -185,6 +192,28 @@ public struct ListChoice<HeaderContent: View, Content: View>: View {
                 return .isSelected
         }
     }
+
+    private init(
+        _ title: String = "",
+        description: String = "",
+        icon: Icon.Content = .none,
+        value: String = "",
+        disclosure: ListChoiceDisclosure = .disclosure(),
+        showSeparator: Bool = true,
+        action: @escaping () -> Void = {},
+        @ViewBuilder content: @escaping () -> Content,
+        @ViewBuilder headerContent: @escaping () -> HeaderContent
+    ) {
+        self.title = title
+        self.description = description
+        self.value = value
+        self.iconContent = icon
+        self.disclosure = disclosure
+        self.showSeparator = showSeparator
+        self.action = action
+        self.content = content
+        self.headerContent = headerContent
+    }
 }
 
 // MARK: - Inits
@@ -201,14 +230,17 @@ public extension ListChoice {
         @ViewBuilder content: @escaping () -> Content,
         @ViewBuilder headerContent: @escaping () -> HeaderContent
     ) {
-        self.title = title
-        self.description = description
-        self.iconContent = icon
-        self.disclosure = disclosure
-        self.showSeparator = showSeparator
-        self.action = action
-        self.content = content
-        self.headerContent = headerContent
+        self.init(
+            title,
+            description: description,
+            icon: icon,
+            value: "",
+            disclosure: disclosure,
+            showSeparator: showSeparator,
+            action: action,
+            content: content,
+            headerContent: headerContent
+        )
     }
 
     /// Creates Orbit ListChoice component with optional vertically centered header content.
@@ -294,6 +326,7 @@ public extension ListChoice where HeaderContent == Text {
             title,
             description: description,
             icon: icon,
+            value: value,
             disclosure: disclosure,
             showSeparator: showSeparator,
             action: action,

--- a/Sources/Orbit/Components/Select.swift
+++ b/Sources/Orbit/Components/Select.swift
@@ -45,9 +45,9 @@ public struct Select: View {
             )
         }
         .accessibilityElement(children: .ignore)
-        .accessibility(label: SwiftUI.Text(label))
-        .accessibility(value: SwiftUI.Text(value ?? ""))
-        .accessibility(hint: SwiftUI.Text(placeholder))
+        .accessibility(label: .init(label))
+        .accessibility(value: .init(value ?? ""))
+        .accessibility(hint: .init(message.description.isEmpty ? placeholder : message.description))
         .accessibility(addTraits: .isButton)
     }
 

--- a/Sources/Orbit/Components/Tile.swift
+++ b/Sources/Orbit/Components/Tile.swift
@@ -97,6 +97,10 @@ public struct Tile<Content: View>: View {
             }
         )
         .buttonStyle(TileButtonStyle(style: tileBorderStyle, status: status, backgroundColor: backgroundColor))
+        .accessibilityElement(children: .ignore)
+        .accessibility(label: .init(title))
+        .accessibility(hint: .init(description))
+        .accessibility(addTraits: .isButton)
     }
 
     @ViewBuilder var buttonContent: some View {

--- a/Sources/Orbit/Support/Accessibility/AccessibilityID.swift
+++ b/Sources/Orbit/Support/Accessibility/AccessibilityID.swift
@@ -38,6 +38,7 @@ public enum AccessibilityID: String {
     case listChoiceTitle                = "orbit.listchoice.title"
     case listChoiceIcon                 = "orbit.listchoice.icon"
     case listChoiceDescription          = "orbit.listchoice.description"
+    case listChoiceValue                = "orbit.listchoice.value"
     case passwordStrengthIndicator      = "orbit.passwordstrengthindicator"
     case radioTitle                     = "orbit.radio.title"
     case radioDescription               = "orbit.radio.description"

--- a/Sources/Orbit/Support/Forms/KeyValueField.swift
+++ b/Sources/Orbit/Support/Forms/KeyValueField.swift
@@ -22,7 +22,6 @@ public struct KeyValueField<Content: View>: View {
             content()
                 .accessibility(.keyValueValue)
         }
-        .accessibilityElement(children: .contain)
     }
 }
 


### PR DESCRIPTION
Form fields are encapsulated, without exposing internal accessibility elements to user (but still accessible for UI tests). Unfortunately, SwiftUI has no way to add `isText/SecureField` trait manually, so inputField has to be a `isButton`.

https://user-images.githubusercontent.com/35844477/172629250-5b7841ea-d4e8-4c27-bedd-f3d26a2c07fa.mov

<img width="663" alt="image" src="https://user-images.githubusercontent.com/35844477/172628188-7807f8df-2652-4a41-8ddf-029cd4507ecf.png">

<img width="656" alt="image" src="https://user-images.githubusercontent.com/35844477/172628249-b5be97f0-fd81-4317-9491-ae1932566993.png">

<img width="671" alt="image" src="https://user-images.githubusercontent.com/35844477/172628346-78a93c51-4ad6-477b-aaca-afd1dcdd0ee6.png">

<img width="582" alt="image" src="https://user-images.githubusercontent.com/35844477/172628456-a42eb4eb-15bb-4c1a-8c9c-81c9e3e65a9c.png">

<img width="680" alt="image" src="https://user-images.githubusercontent.com/35844477/172628542-6be3a81d-4734-4add-a955-72333f77bd1e.png">

<img width="658" alt="image" src="https://user-images.githubusercontent.com/35844477/172628630-cefd3e45-d1b5-4dcc-a3af-7d85174b1b35.png">

<img width="659" alt="image" src="https://user-images.githubusercontent.com/35844477/172628693-307db7bc-e16f-412d-90ac-d94711de08bd.png">

<img width="651" alt="image" src="https://user-images.githubusercontent.com/35844477/172628809-1e0d3c1c-b4e7-4f18-854d-604ae28bf94b.png">
