### PR TITLE
Provide default ListItem init with specific sizing of dot icon.

### DIFF
--- a/Sources/Orbit/Support/Components/Label.swift
+++ b/Sources/Orbit/Support/Components/Label.swift
@@ -13,6 +13,7 @@ public struct Label: View {
     
     let title: String
     let iconContent: Icon.Content
+    let iconSize: Icon.Size?
     let style: Style
     let spacing: CGFloat
 
@@ -30,11 +31,15 @@ public struct Label: View {
 
     @ViewBuilder var icon: some View {
         if let color = style.color {
-            Icon(content: iconContent, size: .label(style))
+            iconView
                 .foregroundColor(color)
         } else {
-            Icon(content: iconContent, size: .label(style))
+            iconView
         }
+    }
+
+    @ViewBuilder var iconView: some View {
+        Icon(content: iconContent, size: iconSize ?? .label(style))
     }
     
     @ViewBuilder var titleView: some View {
@@ -54,10 +59,6 @@ public struct Label: View {
         }
     }
     
-    var iconSize: CGFloat {
-        style.iconSize
-    }
-    
     var isEmpty: Bool {
         title.isEmpty && iconContent.isEmpty
     }
@@ -70,11 +71,13 @@ public extension Label {
     init(
         _ title: String = "",
         icon: Icon.Content = .none,
+        iconSize: Icon.Size? = nil,
         style: Style = .title4,
         spacing: CGFloat = Self.defaultSpacing
     ) {
         self.title = title
         self.iconContent = icon
+        self.iconSize = iconSize
         self.style = style
         self.spacing = spacing
     }
@@ -196,7 +199,6 @@ struct LabelPreviews: PreviewProvider {
 
             Label(icon: .grid)
             
-            Label("Label", icon: .grid)
             Label("Label", icon: .informationCircle)
             
             VStack(alignment: .leading, spacing: 0) {

--- a/Sources/Orbit/Support/Components/ListItem.swift
+++ b/Sources/Orbit/Support/Components/ListItem.swift
@@ -10,6 +10,7 @@ public struct ListItem: View {
 
     let text: String
     let iconContent: Icon.Content
+    let iconSize: Icon.Size?
     let size: Text.Size
     let spacing: CGFloat
     let style: ListItem.Style
@@ -19,6 +20,7 @@ public struct ListItem: View {
         Label(
             text,
             icon: iconContent,
+            iconSize: iconSize,
             style: .text(
                 size,
                 weight: style.weight,
@@ -35,11 +37,12 @@ public struct ListItem: View {
 // MARK: - Inits
 public extension ListItem {
 
-    /// Creates Orbit ListItem component.
+    /// Creates Orbit ListItem component using provided icon.
     init(
         _ text: String = "",
-        icon: Icon.Content = .circleSmall,
+        icon: Icon.Content,
         size: Text.Size = .normal,
+        iconSize: Icon.Size? = nil,
         spacing: CGFloat = .xxSmall,
         style: ListItem.Style = .primary,
         linkAction: @escaping TextLink.Action = { _, _ in }
@@ -47,9 +50,29 @@ public extension ListItem {
         self.text = text
         self.iconContent = icon
         self.size = size
+        self.iconSize = iconSize
         self.spacing = spacing
         self.style = style
         self.linkAction = linkAction
+    }
+
+    /// Creates Orbit ListItem component with default appearance, using `circleSmall` icon.
+    init(
+        _ text: String = "",
+        size: Text.Size = .normal,
+        spacing: CGFloat = .xSmall,
+        style: ListItem.Style = .primary,
+        linkAction: @escaping TextLink.Action = { _, _ in }
+    ) {
+        self.init(
+            text,
+            icon: .circleSmall,
+            size: size,
+            iconSize: .small,
+            spacing: spacing,
+            style: style,
+            linkAction: linkAction
+        )
     }
 }
 


### PR DESCRIPTION
The default `ListItem` in Orbit has a non-matching icon-text sizes which should be supported.

<img width="455" alt="image" src="https://user-images.githubusercontent.com/35844477/173826771-6af5ff2b-5ee2-4540-9513-8183576921cc.png">

<img width="803" alt="image" src="https://user-images.githubusercontent.com/35844477/173826799-3f4232e8-595a-4774-b6e3-79a95d7368d4.png">
