### PR TITLE
Update documentation structure

### DIFF
--- a/Sources/Orbit/Components/BadgeList.swift
+++ b/Sources/Orbit/Components/BadgeList.swift
@@ -113,9 +113,9 @@ public extension BadgeList {
 }
 
 // MARK: - Previews
-public struct BadgeListPreviews: PreviewProvider {
+struct BadgeListPreviews: PreviewProvider {
 
-    public static var previews: some View {
+    static var previews: some View {
         PreviewWrapper {
             standalone
             storybook

--- a/Sources/Orbit/Components/HorizontalScroll.swift
+++ b/Sources/Orbit/Components/HorizontalScroll.swift
@@ -65,7 +65,8 @@ public struct HorizontalScroll<Content: View>: View {
     ///   - spacing: Spacing between items. Default value is `.small`.
     ///   - itemWidth: Horizontal sizing style of all items. Default value is `.ratio()`.
     ///   - itemHeight: Horizontal sizing style of all items. Default value is `.intrinsic`.
-    ///   - maxItemWidth: Maximal item width that caps the result of ``itemWidth``. Default value is derived from `Layout.readableMaxWidth`.
+    ///   - maxItemWidth: Maximal item width that caps the result of `itemWidth`.
+    ///                   Default value is derived from ``Layout/readableMaxWidth``.
     ///   - minHeight: Minimal height of component. Default value is `nil`.
     ///   - horizontalPadding: Horizontal padding inside the ScrollView. Default value is `.xSmall`.
     ///   - verticalPadding: Horizontal padding inside the ScrollView. Can be used to fix overlay issues. Default value is `.xSmall`.

--- a/Sources/Orbit/Components/SocialButton.swift
+++ b/Sources/Orbit/Components/SocialButton.swift
@@ -4,7 +4,7 @@ import SwiftUI
 ///
 /// Social buttons are designed to ease the flow for users signing in.
 /// Don’t use them in any other case or in any complex scenarios.
-
+///
 /// - Related components:
 ///   - ``Button``
 ///

--- a/Sources/Orbit/Components/Tabs.swift
+++ b/Sources/Orbit/Components/Tabs.swift
@@ -71,7 +71,7 @@ public struct Tabs<Content: View>: View {
         .animation(.easeOut(duration: 0.2), value: selectedIndex)
     }
 
-    @ViewBuilder func tab(_ index: Int, lastIndex: Int, _ label: String, style: TabStyle) -> some View {
+    @ViewBuilder func tab(_ index: Int, lastIndex: Int, _ label: String, style: Tab.TabStyle) -> some View {
         Tab(label, style: style)
             .foregroundColor(index == selectedIndex ? style.textColor : .inkNormal)
             .lineLimit(lineLimit)
@@ -99,7 +99,7 @@ public struct Tabs<Content: View>: View {
             .frame(maxHeight: .infinity)
     }
 
-    @ViewBuilder func activeTabBackground(style: TabStyle) -> some View {
+    @ViewBuilder func activeTabBackground(style: Tab.TabStyle) -> some View {
         VStack(spacing: 0) {
             Color.whiteNormal
             underline(style: style)
@@ -111,7 +111,7 @@ public struct Tabs<Content: View>: View {
         .padding(.xxxSmall)
     }
 
-    @ViewBuilder func underline(style: TabStyle) -> some View {
+    @ViewBuilder func underline(style: Tab.TabStyle) -> some View {
         LinearGradient(
             colors: [style.startColor, style.endColor],
             startPoint: .bottomLeading,

--- a/Sources/Orbit/Components/Tile.swift
+++ b/Sources/Orbit/Components/Tile.swift
@@ -62,7 +62,7 @@ public enum TileBorder {
 /// Groups actionable content to make it easy to scan.
 ///
 /// Can be used standalone or wrapped inside a ``TileGroup``.
-
+///
 /// - Related components:
 ///   - ``TileGroup``
 ///   - ``Card``

--- a/Sources/Orbit/Components/TileGroup.swift
+++ b/Sources/Orbit/Components/TileGroup.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 /// Wraps tiles to show related interactions.
-
+///
 /// - Related components:
 ///   - ``Tile``
 ///   - ``Card``

--- a/Sources/Orbit/Components/Toast.swift
+++ b/Sources/Orbit/Components/Toast.swift
@@ -3,23 +3,25 @@ import SwiftUI
 
 /// Toast shows a brief message that’s clear & understandable.
 ///
-/// - Usage:
-///   - Apply the `Toast` component as a `.top` overlay to existing view.
-///   - Provide an instance of `ToastQueue` class which manages a queue of toasts
+/// Apply ``Toast`` as a `.top` overlay to an existing view.
+/// Provide an instance of ``ToastQueue``, which manages a queue of toasts.
 ///
-/// The following example shows a Toast applied on view:
+/// The following example shows a ``Toast`` applied to a view:
 ///
-///     let toastQueue = ToastQueue()
+///    ```swift
+///    let toastQueue = ToastQueue()
 ///
-///     var body: some View {
-///         VStack {
-///             // content over which to display Toasts
-///         }
-///         .overlay(Toast(toastQueue: toastQueue))
-///     }
+///    var body: some View {
+///        VStack {
+///            // content over which to display Toasts
+///        }
+///        .overlay(Toast(toastQueue: toastQueue))
+///    }
+///    ```
 ///
-/// For standalone usage with gesture handling, but no queue management, a ``ToastWrapper`` component can be used.
-/// For standalone usage with no queue management and gesture handling, a ``ToastContent`` component can be used.
+/// Use ``ToastWrapper`` if you need gesture handling, but no queue management.
+///
+/// Use ``ToastContent`` if you don't need gesture handling or queue management.
 ///
 /// - Related components:
 ///   - ``Dialog``

--- a/Sources/Orbit/Orbit.docc/Components/Components.md
+++ b/Sources/Orbit/Orbit.docc/Components/Components.md
@@ -1,0 +1,116 @@
+# Components
+
+Our components are a collection of interface elements that can be reused across the Orbit design system.
+
+## Overview
+
+<!--@START_MENU_TOKEN@-->Text<!--@END_MENU_TOKEN@-->
+
+## Topics
+
+### Accessibility
+
+### Action
+
+- ``Button``
+- ``ButtonGroup``
+- ``ButtonLink``
+- ``ButtonMobileStore``
+- ``SocialButton``
+- ``TextLink``
+
+### Information
+
+- ``Alert``
+- ``Badge``
+- ``BadgeList``
+- ``NotificationBadge``
+- ``Toast``
+
+### Input
+
+- ``Checkbox``
+- ``ChoiceGroup``
+- ``InputField``
+- ``InputFile``
+- ``InputGroup``
+- ``ListChoice``
+- ``Radio``
+- ``Select``
+- ``Textarea``
+
+### Interaction
+
+- ``Collapse``
+- ``Slider``
+- ``Stepper``
+- ``Switch``
+- ``Tag``
+
+### Layout
+
+- ``Layout``
+- ``HorizontalScroll``
+
+### Navigation
+
+- ``Breadcrumbs``
+- ``LinkList``
+- ``NavigationBar``
+- ``Pagination``
+
+### Overlay
+
+- ``Dialog``
+- ``Drawer``
+- ``Modal``
+- ``Popover``
+- ``Tooltip``
+
+### Primitives
+
+### Progress indicators
+
+- ``EmptyState``
+- ``Loading``
+- ``Skeleton``
+- ``Timeline``
+- ``Wizard``
+
+### Responsive
+
+### Structure
+
+- ``Accordion``
+- ``Card``
+- ``Itinerary``
+- ``List``
+- ``PricingTable``
+- ``Separator``
+- ``Table``
+- ``Tabs``
+- ``Tile``
+- ``TileGroup``
+
+### Text
+
+- ``Heading``
+- ``Text``
+
+### Utility components
+
+### Visuals
+
+- ``AirportIllustration``
+- ``CallOutBanner``
+- ``CarrierLogo``
+- ``CountryFlag``
+- ``Coupon``
+- ``FeatureIcon``
+- ``Icon``
+- ``Illustration``
+- ``PictureCard``
+- ``RatingStars``
+- ``Seat``
+- ``ServiceLogo``
+- ``StopoverArrow``

--- a/Sources/Orbit/Orbit.docc/Components/Extensions/Alert.md
+++ b/Sources/Orbit/Orbit.docc/Components/Extensions/Alert.md
@@ -1,0 +1,11 @@
+# ``Orbit/Alert``
+
+@Metadata {
+    @DocumentationExtension(mergeBehavior: append)
+}
+
+## Topics
+
+### Interaction
+
+- ``AlertButtons``

--- a/Sources/Orbit/Orbit.docc/Components/Extensions/Card.md
+++ b/Sources/Orbit/Orbit.docc/Components/Extensions/Card.md
@@ -1,0 +1,15 @@
+# ``Orbit/Card``
+
+@Metadata {
+    @DocumentationExtension(mergeBehavior: append)
+}
+
+## Topics
+
+### Interaction
+
+- ``CardAction``
+
+### Customizing Appearance
+
+- ``CardContentLayout``

--- a/Sources/Orbit/Orbit.docc/Components/Extensions/HorizontalScroll.md
+++ b/Sources/Orbit/Orbit.docc/Components/Extensions/HorizontalScroll.md
@@ -1,0 +1,12 @@
+# ``Orbit/HorizontalScroll``
+
+@Metadata {
+    @DocumentationExtension(mergeBehavior: append)
+}
+
+## Topics
+
+### Customizing Appearance
+
+- ``HorizontalScrollItemWidth``
+- ``HorizontalScrollItemHeight``

--- a/Sources/Orbit/Orbit.docc/Components/Extensions/List.md
+++ b/Sources/Orbit/Orbit.docc/Components/Extensions/List.md
@@ -1,0 +1,11 @@
+# ``Orbit/List``
+
+@Metadata {
+    @DocumentationExtension(mergeBehavior: append)
+}
+
+## Topics
+
+### Adding Content
+
+- ``ListItem``

--- a/Sources/Orbit/Orbit.docc/Components/Extensions/ListChoice.md
+++ b/Sources/Orbit/Orbit.docc/Components/Extensions/ListChoice.md
@@ -1,0 +1,11 @@
+# ``Orbit/ListChoice``
+
+@Metadata {
+    @DocumentationExtension(mergeBehavior: append)
+}
+
+## Topics
+
+### Customizing Appearance
+
+- ``ListChoiceDisclosure``

--- a/Sources/Orbit/Orbit.docc/Components/Extensions/Tabs.md
+++ b/Sources/Orbit/Orbit.docc/Components/Extensions/Tabs.md
@@ -1,0 +1,15 @@
+# ``Orbit/Tabs``
+
+@Metadata {
+    @DocumentationExtension(mergeBehavior: append)
+}
+
+## Topics
+
+### Adding Content
+
+- ``Tab``
+
+### Customizing Appearance
+
+- ``TabsDistribution``

--- a/Sources/Orbit/Orbit.docc/Components/Extensions/Tag.md
+++ b/Sources/Orbit/Orbit.docc/Components/Extensions/Tag.md
@@ -1,0 +1,12 @@
+# ``Orbit/Tag``
+
+@Metadata {
+    @DocumentationExtension(mergeBehavior: append)
+}
+
+## Topics
+
+### Adding Content
+
+- ``TagGroup``
+- ``TagModel``

--- a/Sources/Orbit/Orbit.docc/Components/Extensions/Tile.md
+++ b/Sources/Orbit/Orbit.docc/Components/Extensions/Tile.md
@@ -1,0 +1,16 @@
+# ``Orbit/Tile``
+
+@Metadata {
+    @DocumentationExtension(mergeBehavior: append)
+}
+
+## Topics
+
+### Customizing Appearance
+
+- ``TileBorder``
+- ``TileBorderModifier``
+- ``TileBorderStyle``
+- ``TileButtonStyle``
+- ``TileDisclosure``
+

--- a/Sources/Orbit/Orbit.docc/Components/Extensions/Timeline.md
+++ b/Sources/Orbit/Orbit.docc/Components/Extensions/Timeline.md
@@ -1,0 +1,11 @@
+# ``Orbit/Timeline``
+
+@Metadata {
+    @DocumentationExtension(mergeBehavior: append)
+}
+
+## Topics
+
+### Adding Content
+
+- ``TimelineStep``

--- a/Sources/Orbit/Orbit.docc/Components/Extensions/Toast.md
+++ b/Sources/Orbit/Orbit.docc/Components/Extensions/Toast.md
@@ -1,0 +1,13 @@
+# ``Orbit/Toast``
+
+@Metadata {
+    @DocumentationExtension(mergeBehavior: append)
+}
+
+## Topics
+
+### Displaying Toasts
+
+- ``ToastQueue``
+- ``ToastWrapper``
+- ``ToastContent``

--- a/Sources/Orbit/Orbit.docc/Foundation.md
+++ b/Sources/Orbit/Orbit.docc/Foundation.md
@@ -1,0 +1,37 @@
+# Foundation
+
+<!--@START_MENU_TOKEN@-->Summary<!--@END_MENU_TOKEN@-->
+
+## Overview
+
+<!--@START_MENU_TOKEN@-->Text<!--@END_MENU_TOKEN@-->
+
+## Topics
+
+### Accessibility
+
+- ``AccessibilityID``
+
+### Border radiuses
+
+- ``BorderRadius``
+
+### Colors
+
+- ``Gradient``
+
+### Design tokens
+
+### Elevation
+
+### Icons
+
+### Illustrations
+
+### Orbit principles
+
+### Spacing
+
+- ``Spacing``
+
+### Typography

--- a/Sources/Orbit/Orbit.docc/Orbit.md
+++ b/Sources/Orbit/Orbit.docc/Orbit.md
@@ -4,11 +4,11 @@ Orbit is a SwiftUI component library which provides developers the easiest possi
 
 ## Overview
 
-[Orbit](https://orbit.kiwi) aims to bring order and consistency to all of our products and processes. We elevate user experience and increase the speed and efficiency of how we design and build products.
+Orbit aims to bring order and consistency to all of our products and processes. We elevate user experience and increase the speed and efficiency of how we design and build products.
 
 Orbit is an open-source design system created for specific needs of Kiwi.com and together with that – for needs of travel projects.
 
-This library allows you to integrate the Orbit design system into your iOS SwiftUI project.
+This library allows you to integrate the [Orbit design system](https://orbit.kiwi) into your iOS SwiftUI project.
 
 ## Topics
 
@@ -16,6 +16,18 @@ This library allows you to integrate the Orbit design system into your iOS Swift
 
 - <doc:GettingStarted>
 
+### Components
+
+- <doc:Components>
+
+### Foundation
+
+- <doc:Foundation>
+
 ### Conventions
 
 - <doc:FileStructureAndNaming>
+
+### Other
+
+- <doc:Uncategorized>

--- a/Sources/Orbit/Orbit.docc/Uncategorized.md
+++ b/Sources/Orbit/Orbit.docc/Uncategorized.md
@@ -1,0 +1,57 @@
+# Uncategorized
+
+Supporting types and components under development.
+
+## Overview
+
+<!--@START_MENU_TOKEN@-->Text<!--@END_MENU_TOKEN@-->
+
+## Topics
+
+### Haptics
+
+- ``HapticsProvider``
+
+### Layout
+
+- ``ContainerWidth``
+- ``ContentHeightReader``
+- ``SingleAxisGeometryReader``
+- ``Strut``
+- ``TextStrut``
+
+### Xcode previews support
+
+- ``PreviewWrapper``
+- ``StateWrapper``
+
+### SwiftUI environment
+
+- ``IsExpandedKey``
+- ``IsFadeInKey``
+
+### Other
+
+- ``AssetNameProviding``
+- ``BarButton``
+- ``BorderWidth``
+- ``ChoiceTile``
+- ``ChoiceTileAlignment``
+- ``ChoiceTileIndicator``
+- ``FormFieldLabel``
+- ``FormFieldMessage``
+- ``FormFieldWrapper``
+- ``InputState``
+- ``KeyValue``
+- ``KeyValueField``
+- ``Label``
+- ``MessageType``
+- ``NavigateButton``
+- ``PasswordStrengthIndicator``
+- ``Progress``
+- ``Status``
+- ``Storybook``
+
+### Deprecated
+
+- ``TextLinkView``

--- a/Sources/Orbit/Support/Components/Tab.swift
+++ b/Sources/Orbit/Support/Components/Tab.swift
@@ -1,39 +1,5 @@
 import SwiftUI
 
-public enum TabStyle {
-    case `default`
-    case product
-    case underlined(Color)
-    case underlinedGradient(Orbit.Gradient)
-
-    public var textColor: Color {
-        switch self {
-            case .default:                              return .inkNormal
-            case .product:                              return .inkNormal
-            case .underlined(let color):                return color
-            case .underlinedGradient(let gradient):     return gradient.color
-        }
-    }
-
-    public var startColor: Color {
-        switch self {
-            case .default:                              return .whiteNormal
-            case .product:                              return .productNormal
-            case .underlined(let color):                return color
-            case .underlinedGradient(let gradient):     return gradient.startColor
-        }
-    }
-
-    public var endColor: Color {
-        switch self {
-            case .default:                              return .whiteNormal
-            case .product:                              return .productNormal
-            case .underlined(let color):                return color
-            case .underlinedGradient(let gradient):     return gradient.endColor
-        }
-    }
-}
-
 /// An Orbit sub-component for constructing ``Tabs`` component.
 ///
 /// - Important: The Tab can only be used as a part of ``Tabs`` component, not standalone.
@@ -68,6 +34,40 @@ public struct Tab: View {
 // MARK: - Types
 extension Tab {
 
+    public enum TabStyle {
+        case `default`
+        case product
+        case underlined(Color)
+        case underlinedGradient(Orbit.Gradient)
+
+        public var textColor: Color {
+            switch self {
+                case .default:                              return .inkNormal
+                case .product:                              return .inkNormal
+                case .underlined(let color):                return color
+                case .underlinedGradient(let gradient):     return gradient.color
+            }
+        }
+
+        public var startColor: Color {
+            switch self {
+                case .default:                              return .whiteNormal
+                case .product:                              return .productNormal
+                case .underlined(let color):                return color
+                case .underlinedGradient(let gradient):     return gradient.startColor
+            }
+        }
+
+        public var endColor: Color {
+            switch self {
+                case .default:                              return .whiteNormal
+                case .product:                              return .productNormal
+                case .underlined(let color):                return color
+                case .underlinedGradient(let gradient):     return gradient.endColor
+            }
+        }
+    }
+
     struct PreferenceKey: SwiftUI.PreferenceKey {
         typealias Value = [TabPreference]
 
@@ -81,7 +81,7 @@ extension Tab {
 
 struct TabPreference {
     let label: String
-    let style: TabStyle
+    let style: Tab.TabStyle
     let bounds: Anchor<CGRect>
 }
 


### PR DESCRIPTION
Components/Foundation are now top-level, types are nested under them. Extension files are used to add utility types to their base type. Stuff I couldn't put anywhere is in Uncategorized at the bottom. Could be better, but it's a start.

In general, we need to fill some "overview" sections for articles and components. I would also think about making the "orbit component" links and "important" notes somehow smaller... they stand out quite a lot, but maybe that will get better if we add more text.

### Root
<img width="1127" alt="root" src="https://user-images.githubusercontent.com/12349477/174285802-45e5d076-05a0-4013-9627-aad51aa61295.png">

### Components
<img width="1127" alt="components" src="https://user-images.githubusercontent.com/12349477/174285958-c0a9e33e-9caa-40a5-9f0a-a200bc0368f4.png">

### Component detail (`Tile`) showing topic with utility types
<img width="1127" alt="tile" src="https://user-images.githubusercontent.com/12349477/174286037-d5455fc7-7471-4ba7-bf27-aa283b94a429.png">

### Foundation
This is kind of sparse... maybe we could generate docs for colors / illustrations since we already generate sources for those.
<img width="1127" alt="foundation" src="https://user-images.githubusercontent.com/12349477/174286070-5e9c62ed-0d2e-4383-bd58-aa54a85691d8.png">

### Uncategorized
The "everything else" page.
<img width="1127" alt="uncategorized" src="https://user-images.githubusercontent.com/12349477/174286174-ca3a3af7-0d8f-4772-a053-78f73782460c.png">

