### PR TITLE
Reduce number of snapshots

### DIFF
--- a/Sources/Orbit/Components/Alert.swift
+++ b/Sources/Orbit/Components/Alert.swift
@@ -357,6 +357,10 @@ struct AlertPreviews: PreviewProvider {
             .animation(.default, value: buttons.wrappedValue.isVisible)
         }
     }
+
+    static var snapshot: some View {
+        standalone
+    }
 }
 
 struct AlertDynamicTypePreviews: PreviewProvider {

--- a/Sources/Orbit/Components/Badge.swift
+++ b/Sources/Orbit/Components/Badge.swift
@@ -231,6 +231,10 @@ struct BadgePreviews: PreviewProvider {
         .previewDisplayName("Mix")
     }
 
+    static var snapshot: some View {
+        storybook
+    }
+
     static func badges(_ style: Badge.Style) -> some View {
         HStack(spacing: .medium) {
             Badge("label", style: style)

--- a/Sources/Orbit/Components/BadgeList.swift
+++ b/Sources/Orbit/Components/BadgeList.swift
@@ -148,6 +148,10 @@ struct BadgeListPreviews: PreviewProvider {
         }
         .padding(.medium)
     }
+
+    static var snapshot: some View {
+        storybook
+    }
 }
 
 struct BadgeListDynamicTypePreviews: PreviewProvider {

--- a/Sources/Orbit/Components/Button.swift
+++ b/Sources/Orbit/Components/Button.swift
@@ -386,6 +386,10 @@ struct ButtonPreviews: PreviewProvider {
         .padding(.medium)
     }
 
+    static var snapshot: some View {
+        storybook
+    }
+
     @ViewBuilder static func buttons(_ style: Button.Style) -> some View {
         VStack(spacing: .small) {
             HStack(spacing: .small) {

--- a/Sources/Orbit/Components/ButtonLink.swift
+++ b/Sources/Orbit/Components/ButtonLink.swift
@@ -269,6 +269,10 @@ struct ButtonLinkPreviews: PreviewProvider {
         }
         .padding(.horizontal)
     }
+
+    static var snapshot: some View {
+        storybook
+    }
 }
 
 struct ButtonLinkDynamicTypePreviews: PreviewProvider {

--- a/Sources/Orbit/Components/Card.swift
+++ b/Sources/Orbit/Components/Card.swift
@@ -435,6 +435,10 @@ struct CardPreviews: PreviewProvider {
         .padding(.vertical, .medium)
         .background(Color.cloudLight)
     }
+
+    static var snapshot: some View {
+        standalone
+    }
 }
 
 struct CardDynamicTypePreviews: PreviewProvider {

--- a/Sources/Orbit/Components/CarrierLogo.swift
+++ b/Sources/Orbit/Components/CarrierLogo.swift
@@ -155,4 +155,8 @@ struct CarrierLogoPreviews: PreviewProvider {
         }
         .padding(.medium)
     }
+
+    static var snapshot: some View {
+        standalone
+    }
 }

--- a/Sources/Orbit/Components/Checkbox.swift
+++ b/Sources/Orbit/Components/Checkbox.swift
@@ -205,6 +205,10 @@ struct CheckboxPreviews: PreviewProvider {
         }
     }
 
+    static var snapshot: some View {
+        content(standalone: false)
+    }
+
     static func content(standalone: Bool) -> some View {
         HStack(alignment: .top, spacing: .xLarge) {
             VStack(alignment: .leading, spacing: .xLarge) {

--- a/Sources/Orbit/Components/ChoiceTile.swift
+++ b/Sources/Orbit/Components/ChoiceTile.swift
@@ -408,6 +408,14 @@ struct ChoiceTilePreviews: PreviewProvider {
         choiceTileCentered(titleStyle: .title4, showIllustration: true, isError: true, isSelected: true)
     }
 
+    static var snapshot: some View {
+        VStack(spacing: .medium) {
+            standalone
+            Separator()
+            standaloneCentered
+        }
+    }
+
     static func choiceTile(titleStyle: Heading.Style, showHeader: Bool, isError: Bool, isSelected: Bool) -> some View {
         StateWrapper(initialState: isSelected) { state in
             ChoiceTile(

--- a/Sources/Orbit/Components/CountryFlag.swift
+++ b/Sources/Orbit/Components/CountryFlag.swift
@@ -126,6 +126,10 @@ struct CountryFlagPreviews: PreviewProvider {
         }
         .padding()
     }
+
+    static var snapshot: some View {
+        storybook
+    }
 }
 
 struct CountryFlagDynamicTypePreviews: PreviewProvider {

--- a/Sources/Orbit/Components/Dialog.swift
+++ b/Sources/Orbit/Components/Dialog.swift
@@ -189,6 +189,10 @@ struct DialogPreviews: PreviewProvider {
         )
         .background(Color.whiteNormal)
     }
+
+    static var snapshot: some View {
+        normal
+    }
 }
 
 struct DialogDynamicTypePreviews: PreviewProvider {

--- a/Sources/Orbit/Components/EmptyState.swift
+++ b/Sources/Orbit/Components/EmptyState.swift
@@ -111,4 +111,8 @@ struct EmptyStatePreviews: PreviewProvider {
         EmptyState(title, description: description, illustration: .offline)
             .padding(.medium)
     }
+
+    static var snapshot: some View {
+        standalone
+    }
 }

--- a/Sources/Orbit/Components/Heading.swift
+++ b/Sources/Orbit/Components/Heading.swift
@@ -213,6 +213,10 @@ struct HeadingPreviews: PreviewProvider {
         .previewDisplayName("Multiline")
     }
 
+    static var snapshot: some View {
+        sizes
+    }
+
     @ViewBuilder static func heading(_ content: String, style: Heading.Style) -> some View {
         HStack(alignment: .firstTextBaseline, spacing: .small) {
             Heading(content, style: style)

--- a/Sources/Orbit/Components/HorizontalScroll.swift
+++ b/Sources/Orbit/Components/HorizontalScroll.swift
@@ -318,6 +318,10 @@ struct HorizontalScrollPreviews: PreviewProvider {
         }
     }
 
+    static var snapshot: some View {
+        ratioWidthIntrinsicHeight
+    }
+
     static func intrinsicContent<Content>(@ViewBuilder content: () -> Content) -> some View where Content: View {
         VStack(alignment: .leading) {
             Text("Intrinsic")

--- a/Sources/Orbit/Components/Icon.swift
+++ b/Sources/Orbit/Components/Icon.swift
@@ -468,6 +468,14 @@ struct IconPreviews: PreviewProvider {
         }
         .padding(.medium)
     }
+
+    static var snapshot: some View {
+        VStack(spacing: .medium) {
+            IconPreviews.snapshotSizes
+            Separator()
+            IconPreviews.storybookMix
+        }
+    }
 }
 
 struct IconDynamicTypePreviews: PreviewProvider {

--- a/Sources/Orbit/Components/Illustration.swift
+++ b/Sources/Orbit/Components/Illustration.swift
@@ -102,8 +102,7 @@ struct IllustrationPreviews: PreviewProvider {
             stackFixed
             stackExpanding
 
-            snapshotsExpanding
-            snapshotsSizing
+            snapshot
         }
         .previewLayout(.sizeThatFits)
     }
@@ -126,7 +125,7 @@ struct IllustrationPreviews: PreviewProvider {
     }
     
     static var stackFixed: some View {
-        VStack {
+        VStack(spacing: .medium) {
             Illustration(.womanWithPhone)
                 .border(Color.cloudDark)
             
@@ -138,10 +137,10 @@ struct IllustrationPreviews: PreviewProvider {
     
     static var stackExpanding: some View {
         ScrollView {
-            VStack {
+            VStack(spacing: .medium) {
                 Illustration(.womanWithPhone)
                     .border(Color.cloudDark)
-                
+
                 Illustration(.womanWithPhone)
                     .border(Color.cloudDark)
             }
@@ -149,64 +148,36 @@ struct IllustrationPreviews: PreviewProvider {
         .previewDisplayName("Expanding stack")
     }
 
-    static var snapshotsExpanding: some View {
-        Card {
-            VStack {
-                Text("Frame - Center (default)", size: .small)
-                Illustration(.womanWithPhone, layout: .frame(maxHeight: 100))
-                    .border(Color.cloudDark)
-            }
-            
-            VStack {
-                Text("Frame - Leading", size: .small)
-                Illustration(.womanWithPhone, layout: .frame(maxHeight: 100, alignment: .leading))
-                    .border(Color.cloudDark)
-            }
-            
-            VStack {
-                Text("Frame - Trailing", size: .small)
-                Illustration(.womanWithPhone, layout: .frame(maxHeight: 100, alignment: .trailing))
-                    .border(Color.cloudDark)
-            }
-            
-            VStack {
-                Text("Resizeable", size: .small)
-                Illustration(.womanWithPhone, layout: .resizeable)
-                    .frame(height: 100)
-                    .border(Color.cloudDark)
-            }
-        }
-        .background(Color.cloudLight)
-        .previewDisplayName("Layout - Expanded")
-    }
-
-    static var snapshotsSizing: some View {
+    static var snapshot: some View {
         VStack(alignment: .leading, spacing: .medium) {
-
-            Card("Resizeable") {
-                VStack(alignment: .leading) {
-                    Text("Width = 80", size: .small)
-                    Illustration(.womanWithPhone, layout: .resizeable)
-                        .frame(width: 80)
+            Card("MaxHeight = 80") {
+                VStack {
+                    Text("Frame - Center (default)", size: .small)
+                    Illustration(.womanWithPhone, layout: .frame(maxHeight: 80))
                         .border(Color.cloudDark)
                 }
 
-                VStack(alignment: .leading) {
-                    Text("Height = 80", size: .small)
+                VStack {
+                    Text("Frame - Leading", size: .small)
+                    Illustration(.womanWithPhone, layout: .frame(maxHeight: 80, alignment: .leading))
+                        .border(Color.cloudDark)
+                }
+
+                VStack {
+                    Text("Frame - Trailing", size: .small)
+                    Illustration(.womanWithPhone, layout: .frame(maxHeight: 80, alignment: .trailing))
+                        .border(Color.cloudDark)
+                }
+
+                VStack {
+                    Text("Resizeable", size: .small)
                     Illustration(.womanWithPhone, layout: .resizeable)
                         .frame(height: 80)
                         .border(Color.cloudDark)
                 }
-
-                VStack(alignment: .leading) {
-                    Text("Width = 80, Height = 80", size: .small)
-                    Illustration(.womanWithPhone, layout: .resizeable)
-                        .frame(width: 80, height: 80)
-                        .border(Color.cloudDark)
-                }
             }
 
-            Card("Mix, Height = 30") {
+            Card("MaxHeight = 30") {
                 HStack {
                     VStack(alignment: .leading) {
                         Text("Leading", size: .small)
@@ -234,15 +205,39 @@ struct IllustrationPreviews: PreviewProvider {
                     }
                 }
             }
+
+            Card("Resizeable") {
+                HStack(alignment: .top, spacing: .medium) {
+                    VStack(alignment: .leading) {
+                        Text("Width = 80", size: .small)
+                        Illustration(.womanWithPhone, layout: .resizeable)
+                            .frame(width: 80)
+                            .border(Color.cloudDark)
+                    }
+
+                    VStack(alignment: .leading) {
+                        Text("Height = 80", size: .small)
+                        Illustration(.womanWithPhone, layout: .resizeable)
+                            .frame(height: 80)
+                            .border(Color.cloudDark)
+                    }
+                }
+
+                VStack(alignment: .leading) {
+                    Text("Width = 80, Height = 80", size: .small)
+                    Illustration(.womanWithPhone, layout: .resizeable)
+                        .frame(width: 80, height: 80)
+                        .border(Color.cloudDark)
+                }
+            }
         }
+        .padding(.vertical, .medium)
+        .fixedSize(horizontal: false, vertical: true)
         .background(Color.cloudLight)
         .previewDisplayName("Mixed sizes")
     }
 
     static var storybook: some View {
-        VStack {
-            snapshotsSizing
-            snapshotsExpanding
-        }
+        snapshot
     }
 }

--- a/Sources/Orbit/Components/InputField.swift
+++ b/Sources/Orbit/Components/InputField.swift
@@ -422,6 +422,14 @@ struct InputFieldPreviews: PreviewProvider {
         }
         .padding(.medium)
     }
+    
+    static var snapshot: some View {
+        VStack(spacing: .xLarge) {
+            storybook
+            Separator()
+            storybookPassword
+        }
+    }
 }
 
 struct InputFieldLivePreviews: PreviewProvider {

--- a/Sources/Orbit/Components/KeyValue.swift
+++ b/Sources/Orbit/Components/KeyValue.swift
@@ -107,6 +107,10 @@ struct KeyValuePreviews: PreviewProvider {
         }
         .padding(.medium)
     }
+
+    static var snapshot: some View {
+        storybook
+    }
 }
 
 struct KeyValueDynamicTypePreviews: PreviewProvider {

--- a/Sources/Orbit/Components/List.swift
+++ b/Sources/Orbit/Components/List.swift
@@ -109,6 +109,10 @@ struct ListPreviews: PreviewProvider {
         }
         .padding(.medium)
     }
+
+    static var snapshot: some View {
+        storybook
+    }
 }
 
 struct ListDynamicTypePreviews: PreviewProvider {

--- a/Sources/Orbit/Components/ListChoice.swift
+++ b/Sources/Orbit/Components/ListChoice.swift
@@ -564,6 +564,10 @@ struct ListChoicePreviews: PreviewProvider {
             .frame(maxWidth: .infinity)
             .background(Color.blueLightActive)
     }
+
+    static var snapshot: some View {
+        standalone
+    }
 }
 
 struct ListChoiceDynamicTypePreviews: PreviewProvider {

--- a/Sources/Orbit/Components/NotificationBadge.swift
+++ b/Sources/Orbit/Components/NotificationBadge.swift
@@ -151,6 +151,10 @@ struct NotificationBadgePreviews: PreviewProvider {
         .previewDisplayName("Mix")
     }
 
+    static var snapshot: some View {
+        storybook
+    }
+
     static func badges(_ style: Badge.Style) -> some View {
         HStack(spacing: .medium) {
             NotificationBadge("label", style: style)

--- a/Sources/Orbit/Components/Radio.swift
+++ b/Sources/Orbit/Components/Radio.swift
@@ -192,6 +192,10 @@ struct RadioPreviews: PreviewProvider {
         }
     }
 
+    static var snapshot: some View {
+        content(standalone: false)
+    }
+
     static func content(standalone: Bool) -> some View {
         HStack(alignment: .top, spacing: .xLarge) {
             VStack(alignment: .leading, spacing: .xLarge) {

--- a/Sources/Orbit/Components/Select.swift
+++ b/Sources/Orbit/Components/Select.swift
@@ -160,6 +160,10 @@ struct SelectPreviews: PreviewProvider {
         }
         .padding(.medium)
     }
+
+    static var snapshot: some View {
+        storybook
+    }
 }
 
 struct SelectLivePreviews: PreviewProvider {

--- a/Sources/Orbit/Components/Separator.swift
+++ b/Sources/Orbit/Components/Separator.swift
@@ -118,6 +118,10 @@ struct SeparatorPreviews: PreviewProvider {
         }
         .padding(.medium)
     }
+
+    static var snapshot: some View {
+        storybook
+    }
 }
 
 struct SeparatorDynamicTypePreviews: PreviewProvider {

--- a/Sources/Orbit/Components/Skeleton.swift
+++ b/Sources/Orbit/Components/Skeleton.swift
@@ -145,6 +145,10 @@ struct SkeletonPreviews: PreviewProvider {
         contentAtomic()
     }
 
+    static var snapshot: some View {
+        content(animation: .none)
+    }
+
     static func contentAtomic(animation: Skeleton.Animation = .default) -> some View {
         VStack(alignment: .leading, spacing: .medium) {
             Skeleton(.atomic(.circle), animation: animation)

--- a/Sources/Orbit/Components/SocialButton.swift
+++ b/Sources/Orbit/Components/SocialButton.swift
@@ -155,6 +155,10 @@ struct SocialButtonPreviews: PreviewProvider {
         }
         .padding(.medium)
     }
+
+    static var snapshot: some View {
+        storybook
+    }
 }
 
 struct SocialButtonDynamicTypePreviews: PreviewProvider {

--- a/Sources/Orbit/Components/Switch.swift
+++ b/Sources/Orbit/Components/Switch.swift
@@ -130,6 +130,10 @@ struct SwitchPreviews: PreviewProvider {
         .padding(.medium)
     }
 
+    static var snapshot: some View {
+        storybook
+    }
+
     static func switchView(isOn: Bool, hasIcon: Bool = false, isEnabled: Bool = true) -> some View {
         StateWrapper(initialState: isOn) { isOnState in
             Switch(isOn: isOnState, hasIcon: hasIcon, isEnabled: isEnabled)

--- a/Sources/Orbit/Components/Tabs.swift
+++ b/Sources/Orbit/Components/Tabs.swift
@@ -279,6 +279,10 @@ struct TabsPreviews: PreviewProvider {
         .padding(.medium)
         .previewDisplayName("Live Preview")
     }
+
+    static var snapshot: some View {
+        storybook
+    }
 }
 
 struct TabsDynamicTypePreviews: PreviewProvider {

--- a/Sources/Orbit/Components/Tag.swift
+++ b/Sources/Orbit/Components/Tag.swift
@@ -185,16 +185,19 @@ struct TagPreviews: PreviewProvider {
 
     @ViewBuilder static var storybook: some View {
         VStack(alignment: .leading, spacing: .large) {
-            StateWrapper(initialState: true) { state in
-                Tag(label, icon: .sort, style: .removable(), isSelected: state.wrappedValue) { state.wrappedValue.toggle() }
-            }
-            StateWrapper(initialState: false) { state in
-                Tag(icon: .notificationAdd, isFocused: false, isSelected: state.wrappedValue) { state.wrappedValue.toggle() }
-            }
             stack(style: .default, isFocused: true)
             stack(style: .default, isFocused: false)
             stack(style: .removable(), isFocused: true)
             stack(style: .removable(), isFocused: false)
+            Separator()
+            HStack(spacing: .medium) {
+                StateWrapper(initialState: true) { state in
+                    Tag(label, icon: .sort, style: .removable(), isSelected: state.wrappedValue) { state.wrappedValue.toggle() }
+                }
+                StateWrapper(initialState: false) { state in
+                    Tag(icon: .notificationAdd, isFocused: false, isSelected: state.wrappedValue) { state.wrappedValue.toggle() }
+                }
+            }
         }
         .padding(.medium)
     }
@@ -213,6 +216,10 @@ struct TagPreviews: PreviewProvider {
             }
         }
         .padding(.medium)
+    }
+
+    static var snapshot: some View {
+        storybook
     }
 
     @ViewBuilder static func stack(style: Tag.Style, isFocused: Bool) -> some View {

--- a/Sources/Orbit/Components/Text.swift
+++ b/Sources/Orbit/Components/Text.swift
@@ -559,6 +559,10 @@ struct TextPreviews: PreviewProvider {
         .previewLayout(.sizeThatFits)
     }
 
+    static var snapshot: some View {
+        storybook
+    }
+
     @ViewBuilder static func text(_ content: String, size: Text.Size, weight: Font.Weight) -> some View {
         HStack(alignment: .firstTextBaseline, spacing: .small) {
             Text(content, size: size, weight: weight)

--- a/Sources/Orbit/Components/TextLink.swift
+++ b/Sources/Orbit/Components/TextLink.swift
@@ -177,6 +177,10 @@ struct TextLinkPreviews: PreviewProvider {
             .padding(.medium)
         }
     }
+
+    static var snapshot: some View {
+        storybook
+    }
 }
 
 struct TextLinkDynamicTypePreviews: PreviewProvider {

--- a/Sources/Orbit/Components/Tile.swift
+++ b/Sources/Orbit/Components/Tile.swift
@@ -354,6 +354,10 @@ struct TilePreviews: PreviewProvider {
         }
         .padding(.medium)
     }
+
+    static var snapshot: some View {
+        storybook
+    }
 }
 
 struct TileDynamicTypePreviews: PreviewProvider {

--- a/Sources/Orbit/Components/TileGroup.swift
+++ b/Sources/Orbit/Components/TileGroup.swift
@@ -88,4 +88,8 @@ struct TileGroupPreviews: PreviewProvider {
             border: .separator
         )
     }
+
+    static var snapshot: some View {
+        standalone
+    }
 }

--- a/Sources/Orbit/Components/Timeline.swift
+++ b/Sources/Orbit/Components/Timeline.swift
@@ -144,6 +144,10 @@ struct TimelinePreviews: PreviewProvider {
         .padding(.medium)
     }
 
+    static var snapshot: some View {
+        storybook
+    }
+
     static let steps: [TimelineStepModel] = [
         .init(0, texts[0].label, sublabel: texts[0].sublabel, style: .status(.success), content: texts[0].content),
         .init(1, texts[1].label, sublabel: texts[1].sublabel, content: texts[1].content),

--- a/Sources/Orbit/Components/Toast.swift
+++ b/Sources/Orbit/Components/Toast.swift
@@ -216,7 +216,8 @@ struct ToastPreviews: PreviewProvider {
     }
 
     static var standalone: some View {
-        Toast(toastQueue: toastQueue)
+        ToastContent(description, icon: .grid)
+            .padding(.xLarge)
     }
 
     static var standaloneWrapper: some View {
@@ -249,6 +250,10 @@ struct ToastPreviews: PreviewProvider {
         }
         .padding(.medium)
         .previewDisplayName("Live Preview")
+    }
+
+    static var snapshot: some View {
+        storybook
     }
 }
 


### PR DESCRIPTION
Prepared a **single** representable view for each component to snapshot as `var snapshot`