### PR TITLE
Update DocC generation to use Xcode 14

### DIFF
--- a/.github/workflows/publish-docc.yml
+++ b/.github/workflows/publish-docc.yml
@@ -9,6 +9,9 @@ jobs:
   documentation:
     runs-on: macos-12
     steps:
+    - uses: maxim-lobanov/setup-xcode@v1
+      with:
+        xcode-version: '14.0.0-beta'
     - uses: actions/checkout@v3
     - name: Generate DocC
       run: |


### PR DESCRIPTION
Already updated as a part of testing for the current release.

<img width="1226" alt="Screenshot 2022-08-15 at 16 30 22" src="https://user-images.githubusercontent.com/12349477/184654922-9d9aa67a-3d5f-446b-9a62-43be24d596dd.png">
