### PR TITLE
Make `PreviewWrapper` internal

### DIFF
--- a/Sources/Orbit/Orbit.docc/Uncategorized.md
+++ b/Sources/Orbit/Orbit.docc/Uncategorized.md
@@ -21,7 +21,6 @@ Supporting types and components under development.
 
 ### Xcode previews support
 
-- ``PreviewWrapper``
 - ``StateWrapper``
 
 ### SwiftUI environment

--- a/Sources/Orbit/Support/Previews/PreviewWrapper.swift
+++ b/Sources/Orbit/Support/Previews/PreviewWrapper.swift
@@ -1,17 +1,15 @@
 import SwiftUI
 
-/// Wrapper for preview content with Orbit fonts applied.
-public struct PreviewWrapper<Content: View>: View {
+struct PreviewWrapper<Content: View>: View {
 
     @ViewBuilder let content: Content
 
-    public var body: some View {
+    var body: some View {
         content
     }
 
-    public init(@ViewBuilder content: () -> Content) {
+    init(@ViewBuilder content: () -> Content) {
         Font.registerOrbitFonts()
         self.content = content()
     }
 }
-

--- a/Sources/Orbit/Support/Previews/PreviewWrapper.swift
+++ b/Sources/Orbit/Support/Previews/PreviewWrapper.swift
@@ -15,18 +15,3 @@ public struct PreviewWrapper<Content: View>: View {
     }
 }
 
-/// Wrapper for state based preview content.
-public struct StateWrapper<StateT, Content: View>: View {
-
-    @State public var state: StateT
-    private var content: (_ binding: Binding<StateT>) -> Content
-
-    public init(initialState: StateT, @ViewBuilder content: @escaping (_ binding: Binding<StateT>) -> Content) {
-        self.content = content
-        self._state = State(initialValue: initialState)
-    }
-
-    public var body: some View {
-        content($state)
-    }
-}

--- a/Sources/Orbit/Support/Previews/StateWrapper.swift
+++ b/Sources/Orbit/Support/Previews/StateWrapper.swift
@@ -1,0 +1,17 @@
+import SwiftUI
+
+/// Wrapper for state based preview content.
+public struct StateWrapper<StateT, Content: View>: View {
+
+    @State public var state: StateT
+    private var content: (_ binding: Binding<StateT>) -> Content
+
+    public init(initialState: StateT, @ViewBuilder content: @escaping (_ binding: Binding<StateT>) -> Content) {
+        self.content = content
+        self._state = State(initialValue: initialState)
+    }
+
+    public var body: some View {
+        content($state)
+    }
+}


### PR DESCRIPTION
In the Kiwi app, we currently define a "`PreviewWrapper`" that has a slightly different implementation (by necessity) from the one in here. The thing is that in my opinion we never actually want to use the PreviewWrapper from Orbit, since we pack extra logic into the one in the app - using this one is always a mistake.

So we can either
1. always add a module name to disambiguate - inelegant, error-prone
2. come up with a different name for the one in the app
3. make this one internal

I think the last option makes the most sense - when working on Orbit, everything works the same as before and when importing Orbit elsewhere, this wrapper will not get in the way - clients can still copy it if they want, and presumably add their own logic to it.

At first I also thought about adding an underscore before the Orbit wrapper so it could remain public while not showing up in autocomplete or documentation, but then I realized we don't actually use it in the app at all, so I think there is no point.

If this is merged, all packages in the Kiwi app will use the other version - we can even get rid of the typealias there.