### PR TITLE
Check types are referenced in DocC

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,8 +19,14 @@ jobs:
     - uses: actions/checkout@v3
     - name: Check components have snapshots
       run: Automation/check_components_have_snapshot_tests.sh
+  check-docc-referenced-types:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Check all types are referenced in DocC
+      run: swift package check-documentation
   test:
-    needs: check-components-have-snapshots
+    needs: [build, check-components-have-snapshots, check-docc-referenced-types]
     strategy:
       matrix:
         device: ["iPhone SE (3rd generation)", "iPad (9th generation)"]

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.5
+// swift-tools-version:5.6
 import PackageDescription
 
 // Enable to use bundled Circular Pro fonts (for licensed usage)
@@ -10,6 +10,7 @@ let package = Package(
     products: [
         .library(name: "Orbit", targets: ["Orbit"]),
         .library(name: "OrbitStorybook", targets: ["OrbitStorybook"]),
+        .plugin(name: "CheckDocumentation", targets: ["CheckDocumentation"]),
     ],
     dependencies: [
         .package(
@@ -40,6 +41,15 @@ let package = Package(
                 "Orbit",
                 .product(name: "SnapshotTesting", package: "swift-snapshot-testing")
             ]
+        ),
+        .plugin(
+            name: "CheckDocumentation",
+            capability: .command(
+                intent: .custom(
+                    verb: "check-documentation",
+                    description: "Check if all public types are mentioned in the DocC archive."
+                )
+            )
         )
     ]
 )

--- a/Plugins/CheckDocumentation/main.swift
+++ b/Plugins/CheckDocumentation/main.swift
@@ -1,0 +1,78 @@
+import Foundation
+import PackagePlugin
+
+@main struct CheckDocumentation: CommandPlugin {
+
+    func performCommand(context: PluginContext, arguments: [String]) async throws {
+        for target in context.package.targets(ofType: SwiftSourceModuleTarget.self) where target.kind == .generic {
+            try processTarget(target)
+        }
+    }
+
+    func processTarget(_ target: SwiftSourceModuleTarget) throws {
+
+        guard let doccBundle = Array(target.sourceFiles(withSuffix: "docc")).first else {
+            Diagnostics.remark("No docc archive found for target \(target.name)")
+            return
+        }
+
+        let markdownFilepaths = pathsToMarkdownFiles(in: doccBundle.path)
+
+        // Symbols counted as "referenced" are either found in markdown files in the DocC bundle...
+        let referencedSymbols = try Set(
+            markdownFilepaths
+                .map(symbolReferences(in:))
+                .joined()
+        )
+        // ...or are the actual names of those markdown files.
+        .union(markdownFilepaths.map(\.stem))
+
+        let publicTypeNames = try Set(
+            target.sourceFiles(withSuffix: "swift")
+                .map(\.path)
+                .map(publicTypeNames(in:))
+                .joined()
+        )
+
+        let typesWithoutReference = publicTypeNames.subtracting(referencedSymbols)
+
+        if typesWithoutReference.isEmpty == false {
+            Diagnostics.error("Found types not referenced in DocC: \(typesWithoutReference.sorted().joined(separator: ", "))")
+        }
+    }
+
+    func pathsToMarkdownFiles(in path: Path) -> [Path] {
+
+        guard let doccEnumerator = FileManager.default.enumerator(atPath: path.string) else {
+            Diagnostics.error("Unable to enumerate contents of docc at \(path).")
+            return []
+        }
+
+        return doccEnumerator
+            .compactMap { $0 as? String }
+            .filter { $0.hasSuffix(".md") }
+            .map { path.appending(subpath: $0) }
+    }
+
+    func symbolReferences(in path: Path) throws -> Set<String> {
+        try regexCaptures("``(.*)``", in: path)
+    }
+
+    func publicTypeNames(in path: Path) throws -> Set<String> {
+        try regexCaptures("^public (?:protocol|struct|enum|class|actor) ([A-z1-9]+)", in: path)
+    }
+
+    func regexCaptures(_ pattern: String, in path: Path) throws -> Set<String> {
+
+        let text = try String(contentsOfFile: path.string)
+        let unfortunatelyOldRegex = try NSRegularExpression(pattern: pattern, options: .anchorsMatchLines)
+
+        let nsRange = NSRange(text.startIndex..<text.endIndex, in: text)
+        let captures = unfortunatelyOldRegex.matches(in: text, range: nsRange).map { result in
+            let range = Range(result.range(at: 1), in: text)!
+            return String(text[range])
+        }
+
+        return Set(captures)
+    }
+}

--- a/Sources/Orbit/Orbit.docc/Components/Components.md
+++ b/Sources/Orbit/Orbit.docc/Components/Components.md
@@ -96,6 +96,7 @@ Our components are a collection of interface elements that can be reused across 
 
 - ``Heading``
 - ``Text``
+- ``TextRepresentable``
 
 ### Utility components
 

--- a/Sources/Orbit/Support/TextConcatenation/TextRepresentable.swift
+++ b/Sources/Orbit/Support/TextConcatenation/TextRepresentable.swift
@@ -1,6 +1,8 @@
 import SwiftUI
 
-// A type that can be represented as `SwiftUI.Text`
+/// A type that can be represented as `SwiftUI.Text`
+///
+/// Use the `+` operator to concatenate two `TextRepresentable` elements.
 public protocol TextRepresentable {
 
     func swiftUIText(sizeCategory: ContentSizeCategory) -> SwiftUI.Text?


### PR DESCRIPTION
This is a plugin that checks whether all top-level public types are mentioned in the DocC bundle. This should prevent the generated documentation from showing undocumented types on the main page. This only works for types, not (free) functions!