### PR TITLE
Disable autolabeler

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -16,20 +16,3 @@ exclude-labels:
 template: |
   Changes in this release:
   $CHANGES
-autolabeler:
-  - label: 'maintenance'
-    files:
-      - '*.md'
-  - label: 'bug'
-    branch:
-      - '/fix\/.+/'
-    title:
-      - '/fix/i'
-  - label: 'feature'
-    files: 'Sources/Orbit/Components/**/*'
-  - label: 'automation'
-    files:
-      - 'Automation/**/*'
-      - '.github/**/*'
-  - label: 'documentation'
-    files: 'Sources/Orbit/Orbit.docc/**/*'


### PR DESCRIPTION
Turns out the conditions under which we want to apply labels are not as easily defined and we spend more time removing them anyway.