### PR TITLE
Expose `Orbit` bundle as `.orbit`

### DIFF
--- a/Automation/update_colors.py
+++ b/Automation/update_colors.py
@@ -75,7 +75,7 @@ xcassets_color_template = '''{{
 
 source_filename_plural = f'Colors'
 source_group_template = '\n    // MARK: - {group}'
-source_line_template = '    /// Orbit {description} color.\n    static var {name} = Color("{description}", bundle: .current)'
+source_line_template = '    /// Orbit {description} color.\n    static var {name} = Color("{description}", bundle: .orbit)'
 source_line_template_uicolor = '    /// Orbit {description} color.\n    static var {name} = fromResource(named: "{description}")'
 source_template = '''import SwiftUI
 

--- a/Sources/Orbit/Components/CountryFlag.swift
+++ b/Sources/Orbit/Components/CountryFlag.swift
@@ -12,7 +12,7 @@ public struct CountryFlag: View {
     let border: Border
 
     public var body: some View {
-        SwiftUI.Image(countryCode.rawValue, bundle: .current)
+        SwiftUI.Image(countryCode.rawValue, bundle: .orbit)
             .resizable()
             .scaledToFit()
             .clipShape(clipShape)

--- a/Sources/Orbit/Components/Illustration.swift
+++ b/Sources/Orbit/Components/Illustration.swift
@@ -53,7 +53,7 @@ public extension Illustration {
         layout: Layout = .frame()
     ) {
         self.name = image.assetName
-        self.bundle = .current
+        self.bundle = .orbit
         self.layout = layout
     }
     
@@ -124,7 +124,7 @@ struct IllustrationPreviews: PreviewProvider {
     }
 
     static var customResource: some View {
-        Illustration("WomanWithPhone", bundle: .current, layout: .intrinsic)
+        Illustration("WomanWithPhone", bundle: .orbit, layout: .intrinsic)
             .previewDisplayName()
     }
     

--- a/Sources/Orbit/Foundation/Colors/Colors.swift
+++ b/Sources/Orbit/Foundation/Colors/Colors.swift
@@ -5,177 +5,177 @@ public extension Color {
 
     // MARK: - Blue
     /// Orbit Blue Dark color.
-    static var blueDark = Color("Blue Dark", bundle: .current)
+    static var blueDark = Color("Blue Dark", bundle: .orbit)
     /// Orbit Blue Dark Active color.
-    static var blueDarkActive = Color("Blue Dark Active", bundle: .current)
+    static var blueDarkActive = Color("Blue Dark Active", bundle: .orbit)
     /// Orbit Blue Dark Hover color.
-    static var blueDarkHover = Color("Blue Dark Hover", bundle: .current)
+    static var blueDarkHover = Color("Blue Dark Hover", bundle: .orbit)
     /// Orbit Blue Darker color.
-    static var blueDarker = Color("Blue Darker", bundle: .current)
+    static var blueDarker = Color("Blue Darker", bundle: .orbit)
     /// Orbit Blue Light color.
-    static var blueLight = Color("Blue Light", bundle: .current)
+    static var blueLight = Color("Blue Light", bundle: .orbit)
     /// Orbit Blue Light Active color.
-    static var blueLightActive = Color("Blue Light Active", bundle: .current)
+    static var blueLightActive = Color("Blue Light Active", bundle: .orbit)
     /// Orbit Blue Light Hover color.
-    static var blueLightHover = Color("Blue Light Hover", bundle: .current)
+    static var blueLightHover = Color("Blue Light Hover", bundle: .orbit)
     /// Orbit Blue Normal color.
-    static var blueNormal = Color("Blue Normal", bundle: .current)
+    static var blueNormal = Color("Blue Normal", bundle: .orbit)
     /// Orbit Blue Normal Active color.
-    static var blueNormalActive = Color("Blue Normal Active", bundle: .current)
+    static var blueNormalActive = Color("Blue Normal Active", bundle: .orbit)
     /// Orbit Blue Normal Hover color.
-    static var blueNormalHover = Color("Blue Normal Hover", bundle: .current)
+    static var blueNormalHover = Color("Blue Normal Hover", bundle: .orbit)
 
     // MARK: - Bundle
     /// Orbit Bundle Basic color.
-    static var bundleBasic = Color("Bundle Basic", bundle: .current)
+    static var bundleBasic = Color("Bundle Basic", bundle: .orbit)
     /// Orbit Bundle Medium color.
-    static var bundleMedium = Color("Bundle Medium", bundle: .current)
+    static var bundleMedium = Color("Bundle Medium", bundle: .orbit)
 
     // MARK: - Cloud
     /// Orbit Cloud Dark color.
-    static var cloudDark = Color("Cloud Dark", bundle: .current)
+    static var cloudDark = Color("Cloud Dark", bundle: .orbit)
     /// Orbit Cloud Dark Active color.
-    static var cloudDarkActive = Color("Cloud Dark Active", bundle: .current)
+    static var cloudDarkActive = Color("Cloud Dark Active", bundle: .orbit)
     /// Orbit Cloud Dark Hover color.
-    static var cloudDarkHover = Color("Cloud Dark Hover", bundle: .current)
+    static var cloudDarkHover = Color("Cloud Dark Hover", bundle: .orbit)
     /// Orbit Cloud Light color.
-    static var cloudLight = Color("Cloud Light", bundle: .current)
+    static var cloudLight = Color("Cloud Light", bundle: .orbit)
     /// Orbit Cloud Light Active color.
-    static var cloudLightActive = Color("Cloud Light Active", bundle: .current)
+    static var cloudLightActive = Color("Cloud Light Active", bundle: .orbit)
     /// Orbit Cloud Light Hover color.
-    static var cloudLightHover = Color("Cloud Light Hover", bundle: .current)
+    static var cloudLightHover = Color("Cloud Light Hover", bundle: .orbit)
     /// Orbit Cloud Normal color.
-    static var cloudNormal = Color("Cloud Normal", bundle: .current)
+    static var cloudNormal = Color("Cloud Normal", bundle: .orbit)
     /// Orbit Cloud Normal Active color.
-    static var cloudNormalActive = Color("Cloud Normal Active", bundle: .current)
+    static var cloudNormalActive = Color("Cloud Normal Active", bundle: .orbit)
     /// Orbit Cloud Normal Hover color.
-    static var cloudNormalHover = Color("Cloud Normal Hover", bundle: .current)
+    static var cloudNormalHover = Color("Cloud Normal Hover", bundle: .orbit)
 
     // MARK: - Green
     /// Orbit Green Dark color.
-    static var greenDark = Color("Green Dark", bundle: .current)
+    static var greenDark = Color("Green Dark", bundle: .orbit)
     /// Orbit Green Dark Active color.
-    static var greenDarkActive = Color("Green Dark Active", bundle: .current)
+    static var greenDarkActive = Color("Green Dark Active", bundle: .orbit)
     /// Orbit Green Dark Hover color.
-    static var greenDarkHover = Color("Green Dark Hover", bundle: .current)
+    static var greenDarkHover = Color("Green Dark Hover", bundle: .orbit)
     /// Orbit Green Darker color.
-    static var greenDarker = Color("Green Darker", bundle: .current)
+    static var greenDarker = Color("Green Darker", bundle: .orbit)
     /// Orbit Green Light color.
-    static var greenLight = Color("Green Light", bundle: .current)
+    static var greenLight = Color("Green Light", bundle: .orbit)
     /// Orbit Green Light Active color.
-    static var greenLightActive = Color("Green Light Active", bundle: .current)
+    static var greenLightActive = Color("Green Light Active", bundle: .orbit)
     /// Orbit Green Light Hover color.
-    static var greenLightHover = Color("Green Light Hover", bundle: .current)
+    static var greenLightHover = Color("Green Light Hover", bundle: .orbit)
     /// Orbit Green Normal color.
-    static var greenNormal = Color("Green Normal", bundle: .current)
+    static var greenNormal = Color("Green Normal", bundle: .orbit)
     /// Orbit Green Normal Active color.
-    static var greenNormalActive = Color("Green Normal Active", bundle: .current)
+    static var greenNormalActive = Color("Green Normal Active", bundle: .orbit)
     /// Orbit Green Normal Hover color.
-    static var greenNormalHover = Color("Green Normal Hover", bundle: .current)
+    static var greenNormalHover = Color("Green Normal Hover", bundle: .orbit)
 
     // MARK: - Ink
     /// Orbit Ink Dark color.
-    static var inkDark = Color("Ink Dark", bundle: .current)
+    static var inkDark = Color("Ink Dark", bundle: .orbit)
     /// Orbit Ink Dark Active color.
-    static var inkDarkActive = Color("Ink Dark Active", bundle: .current)
+    static var inkDarkActive = Color("Ink Dark Active", bundle: .orbit)
     /// Orbit Ink Dark Hover color.
-    static var inkDarkHover = Color("Ink Dark Hover", bundle: .current)
+    static var inkDarkHover = Color("Ink Dark Hover", bundle: .orbit)
     /// Orbit Ink Light color.
-    static var inkLight = Color("Ink Light", bundle: .current)
+    static var inkLight = Color("Ink Light", bundle: .orbit)
     /// Orbit Ink Light Active color.
-    static var inkLightActive = Color("Ink Light Active", bundle: .current)
+    static var inkLightActive = Color("Ink Light Active", bundle: .orbit)
     /// Orbit Ink Light Hover color.
-    static var inkLightHover = Color("Ink Light Hover", bundle: .current)
+    static var inkLightHover = Color("Ink Light Hover", bundle: .orbit)
     /// Orbit Ink Normal color.
-    static var inkNormal = Color("Ink Normal", bundle: .current)
+    static var inkNormal = Color("Ink Normal", bundle: .orbit)
     /// Orbit Ink Normal Active color.
-    static var inkNormalActive = Color("Ink Normal Active", bundle: .current)
+    static var inkNormalActive = Color("Ink Normal Active", bundle: .orbit)
     /// Orbit Ink Normal Hover color.
-    static var inkNormalHover = Color("Ink Normal Hover", bundle: .current)
+    static var inkNormalHover = Color("Ink Normal Hover", bundle: .orbit)
 
     // MARK: - Orange
     /// Orbit Orange Dark color.
-    static var orangeDark = Color("Orange Dark", bundle: .current)
+    static var orangeDark = Color("Orange Dark", bundle: .orbit)
     /// Orbit Orange Dark Active color.
-    static var orangeDarkActive = Color("Orange Dark Active", bundle: .current)
+    static var orangeDarkActive = Color("Orange Dark Active", bundle: .orbit)
     /// Orbit Orange Dark Hover color.
-    static var orangeDarkHover = Color("Orange Dark Hover", bundle: .current)
+    static var orangeDarkHover = Color("Orange Dark Hover", bundle: .orbit)
     /// Orbit Orange Darker color.
-    static var orangeDarker = Color("Orange Darker", bundle: .current)
+    static var orangeDarker = Color("Orange Darker", bundle: .orbit)
     /// Orbit Orange Light color.
-    static var orangeLight = Color("Orange Light", bundle: .current)
+    static var orangeLight = Color("Orange Light", bundle: .orbit)
     /// Orbit Orange Light Active color.
-    static var orangeLightActive = Color("Orange Light Active", bundle: .current)
+    static var orangeLightActive = Color("Orange Light Active", bundle: .orbit)
     /// Orbit Orange Light Hover color.
-    static var orangeLightHover = Color("Orange Light Hover", bundle: .current)
+    static var orangeLightHover = Color("Orange Light Hover", bundle: .orbit)
     /// Orbit Orange Normal color.
-    static var orangeNormal = Color("Orange Normal", bundle: .current)
+    static var orangeNormal = Color("Orange Normal", bundle: .orbit)
     /// Orbit Orange Normal Active color.
-    static var orangeNormalActive = Color("Orange Normal Active", bundle: .current)
+    static var orangeNormalActive = Color("Orange Normal Active", bundle: .orbit)
     /// Orbit Orange Normal Hover color.
-    static var orangeNormalHover = Color("Orange Normal Hover", bundle: .current)
+    static var orangeNormalHover = Color("Orange Normal Hover", bundle: .orbit)
 
     // MARK: - Product
     /// Orbit Product Dark color.
-    static var productDark = Color("Product Dark", bundle: .current)
+    static var productDark = Color("Product Dark", bundle: .orbit)
     /// Orbit Product Dark Active color.
-    static var productDarkActive = Color("Product Dark Active", bundle: .current)
+    static var productDarkActive = Color("Product Dark Active", bundle: .orbit)
     /// Orbit Product Dark Hover color.
-    static var productDarkHover = Color("Product Dark Hover", bundle: .current)
+    static var productDarkHover = Color("Product Dark Hover", bundle: .orbit)
     /// Orbit Product Darker color.
-    static var productDarker = Color("Product Darker", bundle: .current)
+    static var productDarker = Color("Product Darker", bundle: .orbit)
     /// Orbit Product Light color.
-    static var productLight = Color("Product Light", bundle: .current)
+    static var productLight = Color("Product Light", bundle: .orbit)
     /// Orbit Product Light Active color.
-    static var productLightActive = Color("Product Light Active", bundle: .current)
+    static var productLightActive = Color("Product Light Active", bundle: .orbit)
     /// Orbit Product Light Hover color.
-    static var productLightHover = Color("Product Light Hover", bundle: .current)
+    static var productLightHover = Color("Product Light Hover", bundle: .orbit)
     /// Orbit Product Normal color.
-    static var productNormal = Color("Product Normal", bundle: .current)
+    static var productNormal = Color("Product Normal", bundle: .orbit)
     /// Orbit Product Normal Active color.
-    static var productNormalActive = Color("Product Normal Active", bundle: .current)
+    static var productNormalActive = Color("Product Normal Active", bundle: .orbit)
     /// Orbit Product Normal Hover color.
-    static var productNormalHover = Color("Product Normal Hover", bundle: .current)
+    static var productNormalHover = Color("Product Normal Hover", bundle: .orbit)
 
     // MARK: - Red
     /// Orbit Red Dark color.
-    static var redDark = Color("Red Dark", bundle: .current)
+    static var redDark = Color("Red Dark", bundle: .orbit)
     /// Orbit Red Dark Active color.
-    static var redDarkActive = Color("Red Dark Active", bundle: .current)
+    static var redDarkActive = Color("Red Dark Active", bundle: .orbit)
     /// Orbit Red Dark Hover color.
-    static var redDarkHover = Color("Red Dark Hover", bundle: .current)
+    static var redDarkHover = Color("Red Dark Hover", bundle: .orbit)
     /// Orbit Red Darker color.
-    static var redDarker = Color("Red Darker", bundle: .current)
+    static var redDarker = Color("Red Darker", bundle: .orbit)
     /// Orbit Red Light color.
-    static var redLight = Color("Red Light", bundle: .current)
+    static var redLight = Color("Red Light", bundle: .orbit)
     /// Orbit Red Light Active color.
-    static var redLightActive = Color("Red Light Active", bundle: .current)
+    static var redLightActive = Color("Red Light Active", bundle: .orbit)
     /// Orbit Red Light Hover color.
-    static var redLightHover = Color("Red Light Hover", bundle: .current)
+    static var redLightHover = Color("Red Light Hover", bundle: .orbit)
     /// Orbit Red Normal color.
-    static var redNormal = Color("Red Normal", bundle: .current)
+    static var redNormal = Color("Red Normal", bundle: .orbit)
     /// Orbit Red Normal Active color.
-    static var redNormalActive = Color("Red Normal Active", bundle: .current)
+    static var redNormalActive = Color("Red Normal Active", bundle: .orbit)
     /// Orbit Red Normal Hover color.
-    static var redNormalHover = Color("Red Normal Hover", bundle: .current)
+    static var redNormalHover = Color("Red Normal Hover", bundle: .orbit)
 
     // MARK: - Social
     /// Orbit Social Facebook color.
-    static var socialFacebook = Color("Social Facebook", bundle: .current)
+    static var socialFacebook = Color("Social Facebook", bundle: .orbit)
     /// Orbit Social Facebook Active color.
-    static var socialFacebookActive = Color("Social Facebook Active", bundle: .current)
+    static var socialFacebookActive = Color("Social Facebook Active", bundle: .orbit)
     /// Orbit Social Facebook Hover color.
-    static var socialFacebookHover = Color("Social Facebook Hover", bundle: .current)
+    static var socialFacebookHover = Color("Social Facebook Hover", bundle: .orbit)
 
     // MARK: - White
     /// Orbit White color.
-    static var whiteNormal = Color("White", bundle: .current)
+    static var whiteNormal = Color("White", bundle: .orbit)
     /// Orbit White Active color.
-    static var whiteActive = Color("White Active", bundle: .current)
+    static var whiteActive = Color("White Active", bundle: .orbit)
     /// Orbit White Darker color.
-    static var whiteDarker = Color("White Darker", bundle: .current)
+    static var whiteDarker = Color("White Darker", bundle: .orbit)
     /// Orbit White Hover color.
-    static var whiteHover = Color("White Hover", bundle: .current)
+    static var whiteHover = Color("White Hover", bundle: .orbit)
     /// Orbit White Lighter color.
-    static var whiteLighter = Color("White Lighter", bundle: .current)
+    static var whiteLighter = Color("White Lighter", bundle: .orbit)
 }

--- a/Sources/Orbit/Foundation/Colors/Tokens.swift
+++ b/Sources/Orbit/Foundation/Colors/Tokens.swift
@@ -3,5 +3,5 @@ import SwiftUI
 public extension Color {
 
     /// Orbit screen background color (darker in both `light` and `dark` modes).
-    static let screen = Color("Screen", bundle: .current)
+    static let screen = Color("Screen", bundle: .orbit)
 }

--- a/Sources/Orbit/Foundation/Colors/UIColor+Extensions.swift
+++ b/Sources/Orbit/Foundation/Colors/UIColor+Extensions.swift
@@ -3,7 +3,7 @@ import UIKit
 extension UIColor {
 
     static func fromResource(named: String) -> UIColor {
-        guard let color = UIColor(named: named, in: Bundle.current, compatibleWith: nil) else {
+        guard let color = UIColor(named: named, in: .orbit, compatibleWith: nil) else {
             preconditionFailure("Cannot find color definition for '\(named)' in bundle")
         }
 

--- a/Sources/Orbit/Foundation/Typography/Font.swift
+++ b/Sources/Orbit/Foundation/Typography/Font.swift
@@ -12,10 +12,10 @@ public extension Font {
     
     /// Fonts used for rendering text in Orbit.
     static var orbitFonts: [Font.Weight: URL?] = [
-        .regular: Bundle.current.url(forResource: "Circular20-Book.otf", withExtension: nil),
-        .medium: Bundle.current.url(forResource: "Circular20-Medium.otf", withExtension: nil),
-        .bold: Bundle.current.url(forResource: "Circular20-Bold.otf", withExtension: nil),
-        .black: Bundle.current.url(forResource: "Circular20-Black.otf", withExtension: nil),
+        .regular: Bundle.orbit.url(forResource: "Circular20-Book.otf", withExtension: nil),
+        .medium: Bundle.orbit.url(forResource: "Circular20-Medium.otf", withExtension: nil),
+        .bold: Bundle.orbit.url(forResource: "Circular20-Bold.otf", withExtension: nil),
+        .black: Bundle.orbit.url(forResource: "Circular20-Black.otf", withExtension: nil),
     ]
 
     /// Creates Orbit font.
@@ -31,7 +31,7 @@ public extension Font {
     /// Registers Orbit fonts set in the `orbitTextFonts` property.
     static func registerOrbitFonts() {
 
-        if let iconsFontURL = Bundle.current.url(forResource: "Icons.ttf", withExtension: nil) {
+        if let iconsFontURL = Bundle.orbit.url(forResource: "Icons.ttf", withExtension: nil) {
             _ = registerFont(at: iconsFontURL)
         }
 

--- a/Sources/Orbit/Support/Resources/Bundle.swift
+++ b/Sources/Orbit/Support/Resources/Bundle.swift
@@ -8,7 +8,7 @@ public extension Bundle {
     /// Normally, `Bundle.module` would be used instead.
     /// Returns the resource bundle associated with the current Swift module.
     /// Xcode bug (rdar://8802612, BUG:FB8893830).
-    static var current: Bundle = {
+    static var orbit: Bundle = {
         let bundleName = "Orbit_Orbit"
 
         let candidates = [

--- a/Sources/Orbit/Support/Resources/Images.swift
+++ b/Sources/Orbit/Support/Resources/Images.swift
@@ -18,7 +18,7 @@ public extension Image {
     }
 
     static func orbit(_ image: Symbol) -> Image {
-        Image(image.assetName, bundle: .current)
+        Image(image.assetName, bundle: .orbit)
     }
 }
 
@@ -27,7 +27,7 @@ public extension UIImage {
     /// Gets UIImage out of image resource.
     static func image(_ resource: String) -> UIImage {
         // swiftlint:disable:next use_orbit_not_image_named
-        guard let uiImage = UIImage(named: resource, in: Bundle.current, compatibleWith: nil) else {
+        guard let uiImage = UIImage(named: resource, in: .orbit, compatibleWith: nil) else {
             assertionFailure("Cannot find image \(resource) in bundle")
             return UIImage()
         }


### PR DESCRIPTION
`Bundle.current` was already public, so just renamed it to `.orbit`.

Resolves #467.