### PR TITLE
Replace some initializer overloads by using default parameter type inference

### DIFF
--- a/Sources/Orbit/Components/Card.swift
+++ b/Sources/Orbit/Components/Card.swift
@@ -126,7 +126,7 @@ public struct Card<Content: View>: View {
 // MARK: - Inits
 public extension Card {
     
-    /// Creates Orbit Card wrapper component over a custom content.
+    /// Creates Orbit Card wrapper component.
     init(
         _ title: String = "",
         description: String = "",
@@ -139,7 +139,7 @@ public extension Card {
         backgroundColor: Color? = .whiteDarker,
         contentLayout: CardContentLayout = .default(),
         contentAlignment: HorizontalAlignment = .leading,
-        @ViewBuilder content: () -> Content
+        @ViewBuilder content: () -> Content = { EmptyView() }
     ) {
         self.title = title
         self.description = description
@@ -153,32 +153,6 @@ public extension Card {
         self.contentLayout = contentLayout
         self.contentAlignment = contentAlignment
         self.content = content()
-    }
-
-    /// Creates Orbit Card wrapper component with empty content.
-    init(
-        _ title: String = "",
-        description: String = "",
-        icon: Icon.Content = .none,
-        action: CardAction = .none,
-        headerSpacing: CGFloat = .medium,
-        showBorder: Bool = true,
-        titleStyle: Heading.Style = .title4,
-        status: Status? = nil,
-        backgroundColor: Color? = .whiteDarker
-    ) where Content == EmptyView {
-        self.init(
-            title,
-            description: description,
-            icon: icon,
-            action: action,
-            headerSpacing: headerSpacing,
-            showBorder: showBorder,
-            titleStyle: titleStyle,
-            status: status,
-            backgroundColor: backgroundColor,
-            content: { EmptyView() }
-        )
     }
 }
 

--- a/Sources/Orbit/Components/ChoiceTile.swift
+++ b/Sources/Orbit/Components/ChoiceTile.swift
@@ -237,8 +237,8 @@ public extension ChoiceTile {
         message: Message? = nil,
         alignment: ChoiceTileAlignment = .default,
         action: @escaping () -> Void,
-        @ViewBuilder content: () -> Content,
-        @ViewBuilder headerContent: () -> HeaderContent
+        @ViewBuilder content: () -> Content = { EmptyView() },
+        @ViewBuilder headerContent: () -> HeaderContent = { EmptyView() }
     ) {
         self.title = title
         self.description = description
@@ -286,39 +286,6 @@ public extension ChoiceTile {
             alignment: alignment,
             action: action,
             content: content,
-            headerContent: { EmptyView() }
-        )
-    }
-
-    /// Creates Orbit ChoiceTile component.
-    init(
-        _ title: String = "",
-        description: String = "",
-        icon: Icon.Content = .none,
-        illustration: Illustration.Image = .none,
-        badgeOverlay: String = "",
-        indicator: ChoiceTileIndicator = .radio,
-        titleStyle: Heading.Style = .title3,
-        isSelected: Bool = false,
-        isError: Bool = false,
-        message: Message? = nil,
-        alignment: ChoiceTileAlignment = .default,
-        action: @escaping () -> Void
-    ) where Content == EmptyView, HeaderContent == EmptyView {
-        self.init(
-            title,
-            description: description,
-            icon: icon,
-            illustration: illustration,
-            badgeOverlay: badgeOverlay,
-            indicator: indicator,
-            titleStyle: titleStyle,
-            isSelected: isSelected,
-            isError: isError,
-            message: message,
-            alignment: alignment,
-            action: action,
-            content: { EmptyView() },
             headerContent: { EmptyView() }
         )
     }

--- a/Sources/Orbit/Components/ListChoice.swift
+++ b/Sources/Orbit/Components/ListChoice.swift
@@ -230,8 +230,8 @@ public extension ListChoice {
         disclosure: ListChoiceDisclosure = .disclosure(),
         showSeparator: Bool = true,
         action: @escaping () -> Void,
-        @ViewBuilder content: () -> Content,
-        @ViewBuilder headerContent: () -> HeaderContent
+        @ViewBuilder content: () -> Content = { EmptyView() },
+        @ViewBuilder headerContent: () -> HeaderContent = { EmptyView() }
     ) {
         self.init(
             title,
@@ -268,29 +268,6 @@ public extension ListChoice {
             EmptyView()
         }
     }
-
-    /// Creates Orbit ListChoice component.
-    init(
-        _ title: String = "",
-        description: String = "",
-        icon: Icon.Content = .none,
-        disclosure: ListChoiceDisclosure = .disclosure(),
-        showSeparator: Bool = true,
-        action: @escaping () -> Void
-    ) where HeaderContent == EmptyView, Content == EmptyView {
-        self.init(
-            title,
-            description: description,
-            icon: icon,
-            disclosure: disclosure,
-            showSeparator: showSeparator,
-            action: action
-        ) {
-            EmptyView()
-        } headerContent: {
-            EmptyView()
-        }
-    }
 }
 
 public extension ListChoice where HeaderContent == Text {
@@ -304,7 +281,7 @@ public extension ListChoice where HeaderContent == Text {
         disclosure: ListChoiceDisclosure = .disclosure(),
         showSeparator: Bool = true,
         action: @escaping () -> Void,
-        @ViewBuilder content: () -> Content
+        @ViewBuilder content: () -> Content = { EmptyView() }
     ) {
         self.init(
             title,
@@ -318,28 +295,6 @@ public extension ListChoice where HeaderContent == Text {
         ) {
             Text(value, weight: .medium)
         }
-    }
-
-    /// Creates Orbit ListChoice component with text based header value.
-    init(
-        _ title: String = "",
-        description: String = "",
-        icon: Icon.Content = .none,
-        value: String,
-        disclosure: ListChoiceDisclosure = .disclosure(),
-        showSeparator: Bool = true,
-        action: @escaping () -> Void
-    ) where Content == EmptyView {
-        self.init(
-            title,
-            description: description,
-            icon: icon,
-            value: value,
-            disclosure: disclosure,
-            showSeparator: showSeparator,
-            action: action,
-            content: { EmptyView() }
-        )
     }
 }
 

--- a/Sources/Orbit/Components/Tile.swift
+++ b/Sources/Orbit/Components/Tile.swift
@@ -189,36 +189,6 @@ public struct Tile<Content: View>: View {
 // MARK: - Inits
 public extension Tile {
     
-    /// Creates Orbit Tile component with custom content.
-    ///
-    /// - Parameters:
-    ///   - style: Appearance of tile. Can be styled to match iOS default table row.
-    init(
-        _ title: String = "",
-        description: String = "",
-        icon: Icon.Content = .none,
-        disclosure: TileDisclosure = .icon(.chevronRight),
-        showBorder: Bool = true,
-        status: Status? = nil,
-        backgroundColor: BackgroundColor? = nil,
-        titleStyle: Heading.Style = .title4,
-        descriptionColor: Text.Color = .inkNormal,
-        action: @escaping () -> Void,
-        @ViewBuilder content: () -> Content
-    ) {
-        self.title = title
-        self.description = description
-        self.iconContent = icon
-        self.disclosure = disclosure
-        self.showBorder = showBorder
-        self.status = status
-        self.backgroundColor = backgroundColor
-        self.titleStyle = titleStyle
-        self.descriptionColor = descriptionColor
-        self.action = action
-        self.content = content()
-    }
-    
     /// Creates Orbit Tile component.
     ///
     /// - Parameters:
@@ -233,21 +203,20 @@ public extension Tile {
         backgroundColor: BackgroundColor? = nil,
         titleStyle: Heading.Style = .title4,
         descriptionColor: Text.Color = .inkNormal,
-        action: @escaping () -> Void
-    ) where Content == EmptyView {
-        self.init(
-            title,
-            description: description,
-            icon: icon,
-            disclosure: disclosure,
-            showBorder: showBorder,
-            status: status,
-            backgroundColor: backgroundColor,
-            titleStyle: titleStyle,
-            descriptionColor: descriptionColor,
-            action: action,
-            content: { EmptyView() }
-        )
+        action: @escaping () -> Void,
+        @ViewBuilder content: () -> Content = { EmptyView() }
+    ) {
+        self.title = title
+        self.description = description
+        self.iconContent = icon
+        self.disclosure = disclosure
+        self.showBorder = showBorder
+        self.status = status
+        self.backgroundColor = backgroundColor
+        self.titleStyle = titleStyle
+        self.descriptionColor = descriptionColor
+        self.action = action
+        self.content = content()
     }
 }
 

--- a/Sources/Orbit/Support/Components/TimelineItem.swift
+++ b/Sources/Orbit/Support/Components/TimelineItem.swift
@@ -66,13 +66,13 @@ public struct TimelineItem<Footer: View>: View {
 
 public extension TimelineItem {
 
-    /// Creates Orbit TimelineItem component with text details and custom content at the bottom.
+    /// Creates Orbit TimelineItem component with text details and optional custom content at the bottom.
     init(
         _ label: String = "",
         sublabel: String = "",
         type: TimelineItemType = .future,
         description: String = "",
-        @ViewBuilder footer: () -> Footer
+        @ViewBuilder footer: () -> Footer = { EmptyView() }
     ) {
 
         self.label = label
@@ -80,19 +80,6 @@ public extension TimelineItem {
         self.type = type
         self.description = description
         self.footer = footer()
-    }
-}
-
-public extension TimelineItem where Footer == EmptyView {
-
-    /// Creates Orbit TimelineItem component with text details.
-    init(
-        _ label: String,
-        sublabel: String = "",
-        type: TimelineItemType = .future,
-        description: String = ""
-    ) {
-        self.init(label, sublabel: sublabel, type: type, description: description, footer: { EmptyView() })
     }
 }
 

--- a/Sources/Orbit/Support/Forms/FieldWrapper.swift
+++ b/Sources/Orbit/Support/Forms/FieldWrapper.swift
@@ -41,36 +41,13 @@ public extension FieldWrapper {
         messageHeight: Binding<CGFloat> = .constant(0),
         @ViewBuilder content: () -> Content,
         @ViewBuilder label: () -> Label,
-        @ViewBuilder footer: () -> Footer
+        @ViewBuilder footer: () -> Footer = { EmptyView() }
     ) {
         self.message = message
         self._messageHeight = messageHeight
         self.content = content()
         self.label = label()
         self.footer = footer()
-    }
-}
-
-public extension FieldWrapper where Footer == EmptyView {
-
-    /// Creates Orbit wrapper around form field content with a custom label.
-    ///
-    /// `FieldLabel` is a default component for constructing custom label.
-    init(
-        message: Message? = nil,
-        messageHeight: Binding<CGFloat> = .constant(0),
-        @ViewBuilder content: () -> Content,
-        @ViewBuilder label: () -> Label
-    ) {
-        self.init(
-            message: message,
-            messageHeight: messageHeight,
-            content: content,
-            label: label,
-            footer: {
-                EmptyView()
-            }
-        )
     }
 }
 
@@ -85,7 +62,7 @@ public extension FieldWrapper where Label == FieldLabel {
         message: Message? = nil,
         messageHeight: Binding<CGFloat> = .constant(0),
         @ViewBuilder content: () -> Content,
-        @ViewBuilder footer: () -> Footer
+        @ViewBuilder footer: () -> Footer = { EmptyView() }
     ) {
         self.init(
             message: message,
@@ -95,33 +72,6 @@ public extension FieldWrapper where Label == FieldLabel {
                 FieldLabel(label, accentColor: labelAccentColor, linkColor: labelLinkColor, linkAction: labelLinkAction)
             },
             footer: footer
-        )
-    }
-}
-
-public extension FieldWrapper where Label == FieldLabel, Footer == EmptyView {
-
-    /// Creates Orbit wrapper around form field content.
-    init(
-        _ label: String,
-        labelAccentColor: UIColor? = nil,
-        labelLinkColor: TextLink.Color = .primary,
-        labelLinkAction: @escaping TextLink.Action = { _, _ in },
-        message: Message? = nil,
-        messageHeight: Binding<CGFloat> = .constant(0),
-        @ViewBuilder content: () -> Content
-    ) {
-        self.init(
-            label,
-            labelAccentColor: labelAccentColor,
-            labelLinkColor: labelLinkColor,
-            labelLinkAction: labelLinkAction,
-            message: message,
-            messageHeight: messageHeight,
-            content: content,
-            footer: {
-                EmptyView()
-            }
         )
     }
 }


### PR DESCRIPTION
We can use [Type inference from default expressions](https://github.com/apple/swift-evolution/blob/main/proposals/0347-type-inference-from-default-exprs.md) introduced in Swift 5.7 to remove some init overloads. We still need a few because of [Forward-scan matching for trailing closures](https://github.com/apple/swift-evolution/blob/main/proposals/0286-forward-scan-trailing-closures.md).