### PR TITLE
Keyboard autocomplete appends the suggestion at the end of InputField binding

### DIFF
--- a/Sources/Orbit/Components/InputField.swift
+++ b/Sources/Orbit/Components/InputField.swift
@@ -33,7 +33,7 @@ public struct InputField: View, TextFieldBuildable {
 
     // Builder properties (keyboard related)
     var autocapitalizationType: UITextAutocapitalizationType = .none
-    var isAutocorrectionDisabled: Bool = false
+    var isAutocorrectionDisabled: Bool? = false
     var keyboardType: UIKeyboardType = .default
     var returnKeyType: UIReturnKeyType = .default
     var textContentType: UITextContentType?

--- a/Sources/Orbit/Support/TextFields/TextField.swift
+++ b/Sources/Orbit/Support/TextFields/TextField.swift
@@ -25,7 +25,7 @@ public struct TextField: UIViewRepresentable, TextFieldBuildable {
 
     // Builder properties (keyboard related)
     var returnKeyType: UIReturnKeyType = .default
-    var isAutocorrectionDisabled: Bool = false
+    var isAutocorrectionDisabled: Bool? = nil
     var keyboardType: UIKeyboardType = .default
     var textContentType: UITextContentType?
     var autocapitalizationType: UITextAutocapitalizationType = .sentences
@@ -57,9 +57,21 @@ public struct TextField: UIViewRepresentable, TextFieldBuildable {
 
         // Keyboard related
         uiView.returnKeyType = returnKeyType
-        uiView.autocorrectionType = isAutocorrectionDisabled ? .no : .default
         uiView.keyboardType = keyboardType
         uiView.textContentType = textContentType
+
+        if let isAutocorrectionDisabled {
+            uiView.autocorrectionType = isAutocorrectionDisabled ? .no : .yes
+        } else {
+            switch textContentType {
+                case UITextContentType.emailAddress, UITextContentType.password, UITextContentType.newPassword:
+                    // If not specified, disable autocomplete for these content types
+                    uiView.autocorrectionType = .no
+                default:
+                    uiView.autocorrectionType = .default
+            }
+        }
+
         uiView.autocapitalizationType = autocapitalizationType
         uiView.shouldDeleteBackwardAction = shouldDeleteBackwardAction
 

--- a/Sources/Orbit/Support/TextFields/TextFieldBuildable.swift
+++ b/Sources/Orbit/Support/TextFields/TextFieldBuildable.swift
@@ -6,7 +6,7 @@ import SwiftUI
 protocol TextFieldBuildable {
 
     var autocapitalizationType: UITextAutocapitalizationType { get set }
-    var isAutocorrectionDisabled: Bool { get set }
+    var isAutocorrectionDisabled: Bool? { get set }
     var keyboardType: UIKeyboardType { get set }
     var returnKeyType: UIReturnKeyType { get set }
     var textContentType: UITextContentType? { get set }
@@ -30,7 +30,7 @@ public extension TextField {
     }
 
     /// Returns a modified Orbit TextField with provided autocorrection type.
-    func autocorrectionDisabled(_ disable: Bool = true) -> Self {
+    func autocorrectionDisabled(_ disable: Bool? = true) -> Self {
         set(\.isAutocorrectionDisabled, to: disable)
     }
 
@@ -63,7 +63,7 @@ public extension InputField {
     }
 
     /// Returns a modified Orbit InputField with provided autocorrection type.
-    func autocorrectionDisabled(_ disable: Bool = true) -> Self {
+    func autocorrectionDisabled(_ disable: Bool? = true) -> Self {
         set(\.isAutocorrectionDisabled, to: disable)
     }
 


### PR DESCRIPTION
Caused by various bugs in UIKit call sequence of `shouldChangeCharactersIn` in combination with autocomplete/autocorrect, especially in combination with emailAddress content type.

Fixed by updating the binding by a real value which seems to be stable and correct even in various cut&paste or autocomplete scenarios.

Switched the autocomplete to 3-state flag. It can also be used in future to default some types of content (email, password) to `true`, so the call site does not have to repeat it over again, yet still would be able to turn it on, if really needed.