### PR TITLE
Apply accessibility id to knob, not the whole track

### DIFF
--- a/Sources/Orbit/Components/Slider.swift
+++ b/Sources/Orbit/Components/Slider.swift
@@ -99,9 +99,9 @@ public struct Slider<Value>: View where Value: SliderValue, Value.Stride: Binary
             .background(strokedPath(from: firstThumbPosition, to: secondThumbPosition))
         } else {
             firstThumb(atPosition: firstThumbPosition, width: thumbTrackWidth)
+                .accessibility(.sliderFirstThumb)
                 .padding(.leading, thumbRadius)
                 .background(strokedPath(from: 0, to: firstThumbPosition))
-                .accessibility(.sliderFirstThumb)
         }
     }
 


### PR DESCRIPTION
Dummy mistake but completely changes what we get in return by accessiblity ID