### PR TITLE
Add focus modifier for inputfields

### DIFF
--- a/Sources/Orbit/Support/Environment Keys/Identifier.swift
+++ b/Sources/Orbit/Support/Environment Keys/Identifier.swift
@@ -18,6 +18,7 @@ public extension View {
     /// Binds a view’s identity to the given proxy value.
     ///
     /// This Orbit override adds the custom `IDPreferenceKey` preference and `identifier` environment value on top of native identity.
+    /// This `identifier` is a necessary property of components that are used in some Orbit components or modifiers.
     func identifier<ID: Hashable>(_ id: ID) -> some View {
         self
             .environment(\.identifier, id)

--- a/Sources/Orbit/Support/Environment Keys/InputFieldFocusKey.swift
+++ b/Sources/Orbit/Support/Environment Keys/InputFieldFocusKey.swift
@@ -1,0 +1,35 @@
+import SwiftUI
+
+struct InputFieldFocus {
+    let binding: Binding<AnyHashable?>
+}
+
+struct InputFieldFocusKey: EnvironmentKey {
+    static var defaultValue: InputFieldFocus?
+}
+
+extension EnvironmentValues {
+
+    var inputFieldFocus: InputFieldFocus? {
+        get { self[InputFieldFocusKey.self] }
+        set { self[InputFieldFocusKey.self] = newValue }
+    }
+}
+
+public extension View {
+
+    /// Assigns a focus binding to Orbit text fields in a view.
+    ///
+    /// When a value of a binding matches the `identifier` of a specific Orbit text field, that text field becomes focused.
+    func inputFieldFocus<Value>(_ binding: Binding<Value?>) -> some View where Value: Hashable {
+        environment(
+            \.inputFieldFocus,
+            .init(
+                binding: .init(
+                    get: { binding.wrappedValue as AnyHashable? },
+                    set: { binding.wrappedValue = $0 as? Value }
+                )
+            )
+        )
+    }
+}


### PR DESCRIPTION
The modifier has a different API than the native one. Ours can be specified only once for the whole screen, using our existing `identifier` identity. We can later add another modifier mimicking the native one, if needed.

Native:
```
@FocusState private var focus: FieldType?

TextField(...)
   .focused($focus, equals: .firstname)

TextField(...)
   .focused($focus, equals: .middleName)

TextField(...)
   .focused($focus, equals: .lastname)
```

Orbit:

```
VStack(alignment: .leading, spacing: .large) {
    InputField(...)
        .identifier(Input.one)

    InputField(...)
        .identifier(Input.two)

    InputField(...)
        .identifier(Input.three)
}
.inputFieldFocus($focus)
```

https://github.com/kiwicom/orbit-swiftui/assets/35844477/0b548a9a-4622-47c0-adaf-0ac510a0905e

