### PR TITLE
Fix DocC warnings

### DIFF
--- a/Sources/Orbit/Components/ChoiceTile.swift
+++ b/Sources/Orbit/Components/ChoiceTile.swift
@@ -17,7 +17,7 @@ import SwiftUI
 /// The title and icon colors can be modified by ``textColor(_:)`` and ``iconColor(_:)`` modifiers.
 /// The icon size can be modified by ``iconSize(custom:)`` modifier.
 /// 
-/// The default background can be overridden by ``backgroundStyle(_:)-9odue`` modifier.
+/// The default background can be overridden by ``SwiftUI/View/backgroundStyle(_:)`` modifier.
 /// 
 /// ```swift
 /// ChoiceTile("Full", icon: .informationCircle, isSelected: $isFull) {

--- a/Sources/Orbit/Components/Heading.swift
+++ b/Sources/Orbit/Components/Heading.swift
@@ -15,7 +15,7 @@ import SwiftUI
 /// - Modifiers applied directly to `Heading` that return the same type, such as ``textColor(_:)-80ix5`` or ``textAccentColor(_:)-k54u``. 
 /// These can also be used for concatenation with other Orbit textual components like ``Text`` or ``Icon``. 
 /// See the `InstanceMethods` section below for full list.
-/// - Modifiers applied to view hierarchy, such as ``textColor(_:)-828ud`` or ``textIsCopyable(_:)``. 
+/// - Modifiers applied to view hierarchy, such as ``SwiftUI/View/textColor(_:)`` or ``SwiftUI/View/textIsCopyable(_:)``. 
 /// See a full list of `View` extensions in documentation.
 /// 
 /// ```swift

--- a/Sources/Orbit/Components/Icon.swift
+++ b/Sources/Orbit/Components/Icon.swift
@@ -21,7 +21,7 @@ import SwiftUI
 /// - Modifiers applied directly to `Icon` that return the same type, such as ``iconColor(_:)-1h3pr`` or ``iconSize(_:)-4p0n3``. 
 /// These can also be used for concatenation with other Orbit textual components like ``Heading`` or ``Text``. 
 /// See the `InstanceMethods` section below for full list.
-/// - Modifiers applied to view hierarchy, such as ``iconColor(_:)-e48e`` or ``iconSize(_:)-1pg82``. 
+/// - Modifiers applied to view hierarchy, such as ``SwiftUI/View/iconColor(_:)`` or ``SwiftUI/View/iconSize(_:)``. 
 /// See a full list of `View` extensions in documentation.
 /// 
 /// ```swift

--- a/Sources/Orbit/Components/ListChoice.swift
+++ b/Sources/Orbit/Components/ListChoice.swift
@@ -37,7 +37,7 @@ import SwiftUI
 /// The title and icon colors can be modified by ``textColor(_:)`` and ``iconColor(_:)`` modifiers.
 /// The icon size can be modified by ``iconSize(custom:)`` modifier.
 /// 
-/// The default background can be overridden by ``backgroundStyle(_:)-9odue`` modifier.
+/// The default background can be overridden by ``SwiftUI/View/backgroundStyle(_:)`` modifier.
 /// 
 /// A ``Status`` can be modified by ``status(_:)`` modifier:
 ///

--- a/Sources/Orbit/Components/Text.swift
+++ b/Sources/Orbit/Components/Text.swift
@@ -24,7 +24,7 @@ import SwiftUI
 /// - Modifiers applied directly to `Text` that return the same type, such as ``textColor(_:)-7qk2x`` or ``textAccentColor(_:)-xmqw``. 
 /// These can also be used for concatenation with other Orbit textual components like ``Heading`` or ``Icon``. 
 /// See the `InstanceMethods` section below for full list.
-/// - Modifiers applied to view hierarchy, such as ``textColor(_:)-828ud`` or ``textIsCopyable(_:)``.
+/// - Modifiers applied to view hierarchy, such as ``SwiftUI/View/textColor(_:)`` or ``SwiftUI/View/textIsCopyable(_:)``.
 /// See a full list of `View` extensions in documentation.
 /// 
 /// ```swift

--- a/Sources/Orbit/Components/Tile.swift
+++ b/Sources/Orbit/Components/Tile.swift
@@ -19,7 +19,7 @@ import SwiftUI
 /// The title and icon colors can be modified by ``textColor(_:)`` and ``iconColor(_:)`` modifiers.
 /// The icon size can be modified by ``iconSize(custom:)`` modifier.
 /// 
-/// The default background can be overridden by ``backgroundStyle(_:)-9odue`` modifier.
+/// The default background can be overridden by ``SwiftUI/View/backgroundStyle(_:)`` modifier.
 /// 
 /// A ``Status`` can be modified by ``status(_:)`` modifier:
 ///

--- a/Sources/Orbit/Orbit.docc/Components/Components.md
+++ b/Sources/Orbit/Orbit.docc/Components/Components.md
@@ -13,9 +13,11 @@ Our components are a collection of interface elements that can be reused across 
 ### Action
 
 - ``Button``
-- ``ButtonGroup``
+
+[//]: # (ButtonGroup)
 - ``ButtonLink``
-- ``ButtonMobileStore``
+
+[//]: # (ButtonMobileStore)
 - ``SocialButton``
 - ``TextLink``
 
@@ -32,11 +34,13 @@ Our components are a collection of interface elements that can be reused across 
 ### Input
 
 - ``Checkbox``
-- ``ChoiceGroup``
+
+[//]: # (ChoiceGroup)
 - ``ChoiceTile``
 - ``InputField``
-- ``InputFile``
-- ``InputGroup``
+
+[//]: # (InputFile)
+[//]: # (InputGroup)
 - ``ListChoice``
 - ``Radio``
 - ``SegmentedSwitch``
@@ -56,42 +60,47 @@ Our components are a collection of interface elements that can be reused across 
 - ``Layout``
 - ``HorizontalScroll``
 
-### Navigation
-
-- ``Breadcrumbs``
-- ``LinkList``
-- ``NavigationBar``
-- ``Pagination``
+[//]: # (### Navigation)
+[//]: # (Breadcrumbs)
+[//]: # (LinkList)
+[//]: # (NavigationBar
+[//]: # (Pagination
 
 ### Overlay
 
 - ``Dialog``
-- ``Drawer``
-- ``Modal``
-- ``Popover``
-- ``Tooltip``
+
+[//]: # (Drawer)
+[//]: # (Modal)
+[//]: # (Popover)
+[//]: # (Tooltip)
 
 ### Primitives
 
 ### Progress indicators
 
 - ``EmptyState``
-- ``Loading``
+
+[//]: # (Loading)
 - ``Skeleton``
 - ``Timeline``
-- ``Wizard``
+
+[//]: # (Wizard)
 
 ### Responsive
 
 ### Structure
 
-- ``Accordion``
+[//]: # (Accordion)
 - ``Card``
-- ``Itinerary``
+
+[//]: # (Itinerary)
 - ``List``
-- ``PricingTable``
+
+[//]: # (PricingTable)
 - ``Separator``
-- ``Table``
+
+[//]: # (Table)
 - ``Tabs``
 - ``Tile``
 - ``TileGroup``
@@ -107,16 +116,18 @@ Our components are a collection of interface elements that can be reused across 
 
 ### Visuals
 
-- ``AirportIllustration``
-- ``CallOutBanner``
+[//]: # (AirportIllustration)
+[//]: # (CallOutBanner)
 - ``CarrierLogo``
 - ``CountryFlag``
 - ``Coupon``
-- ``FeatureIcon``
+
+[//]: # (FeatureIcon)
 - ``Icon``
-- ``Illustration``
-- ``PictureCard``
-- ``RatingStars``
-- ``Seat``
-- ``ServiceLogo``
-- ``StopoverArrow``
+
+[//]: # (Illustration (Extracted to `OrbitIllustrations`))
+[//]: # (PictureCard)
+[//]: # (RatingStars)
+[//]: # (Seat)
+[//]: # (ServiceLogo)
+[//]: # (StopoverArrow)

--- a/Sources/Orbit/Orbit.docc/FileStructureAndNaming.md
+++ b/Sources/Orbit/Orbit.docc/FileStructureAndNaming.md
@@ -48,7 +48,7 @@ Most Foundation types and values are accessed using extensions on related types.
 
 #### Spacing
 
-Use the ``Spacing`` enum with `CGFloat` extensions to access values.
+Use the ``Orbit/Spacing`` enum with `CGFloat` extensions to access values.
 
 ```swift
 VStack(spacing: .medium) {

--- a/Sources/Orbit/Orbit.docc/Foundation/Elevation.md
+++ b/Sources/Orbit/Orbit.docc/Foundation/Elevation.md
@@ -10,7 +10,7 @@ Note: [Orbit definition](https://orbit.kiwi/foundation/elevation/)
 
 ## Adding elevation to a view
 
-Use the `View.elevation(_:)` modifier to add elevation to a view:
+Use the ``SwiftUI/View/elevation(_:shadowColor:shape:)`` modifier to add elevation to a view:
 
 ```swift
 // Level 3 elevation
@@ -37,7 +37,7 @@ in order to achieve better performance.
 
 ## Suppressing existing elevation
 
-Elevation in child views can be optionally disabled by using ``IsElevationEnabledKey`` environment key,
+Elevation in child views can be optionally disabled by using `isElevationEnabled` environment value,
 typically in order to disable elevation that is present by default on some Orbit components,
 to be able to apply the elevation for a subset of components at once.
 

--- a/Sources/Orbit/Orbit.docc/Uncategorized.md
+++ b/Sources/Orbit/Orbit.docc/Uncategorized.md
@@ -24,14 +24,6 @@ Supporting types and components under development.
 - ``StateWrapper``
 - ``StateObjectWrapper``
 
-### SwiftUI environment
-
-- ``IsElevationEnabledKey``
-- ``IsExpandedKey``
-- ``IsFadeInEnabledKey``
-- ``IsTileSeparatorVisibleKey``
-- ``ScreenLayoutPaddingKey``
-
 ### Forms
 
 - ``FieldLabel``
@@ -68,7 +60,6 @@ Supporting types and components under development.
 - ``IconButton``
 - ``IdealSizeValue``
 - ``KeyValueField``
-- ``LazyVStack``
 - ``NavigationButton``
 - ``PasswordStrengthIndicator``
 - ``Progress``

--- a/Sources/Orbit/Support/Environment Keys/InputFieldShouldReturnActionKey.swift
+++ b/Sources/Orbit/Support/Environment Keys/InputFieldShouldReturnActionKey.swift
@@ -28,7 +28,7 @@ public extension View {
     /// Set the `textFieldShouldReturn` action for Orbit text fields that decides whether to process the keyboard Return button. 
     /// 
     /// By default, pressing the Return button will be processed and the keyboard will be dismissed, 
-    /// triggering the optional ``inputFieldReturnAction(_:)-9w13u`` after the processing.
+    /// triggering the optional ``SwiftUI/View/inputFieldReturnAction(_:)-9w13u`` after the processing.
     /// 
     /// If the Return button should be ignored instead, return `false` from the provided action. 
     /// If the focus should be switched to another field, modify the focus value in the provided action.
@@ -42,12 +42,12 @@ public extension View {
     /// Set the `textFieldShouldReturn` action for Orbit identifiable text fields that decides whether to process the keyboard Return button.
     /// 
     /// By default, pressing the Return button will be processed and the keyboard will be dismissed, 
-    /// triggering the optional ``inputFieldReturnAction(_:)-1mvv4`` after the processing.
+    /// triggering the optional ``SwiftUI/View/inputFieldReturnAction(_:)-9w13u`` after the processing.
     /// 
     /// If the Return button should be ignored instead, return `false` from the provided action. 
     /// If the focus should be switched to another field, modify the focus value in the provided action.
     ///
-    /// - Important: Mark the associated Orbit text field with ``identifier(_:)`` modifier to set its identity.
+    /// - Important: Mark the associated Orbit text field with ``SwiftUI/View/identifier(_:)`` modifier to set its identity.
     ///
     /// - Parameters:
     ///   - action: A  handler that is executed to ask whether to process the pressing of the Return button for the identifiable text field inside the view hierarchy.

--- a/Sources/Orbit/Support/Layout/ScreenLayoutModifier.swift
+++ b/Sources/Orbit/Support/Layout/ScreenLayoutModifier.swift
@@ -69,7 +69,7 @@ public extension View {
     ///
     /// Screen layout adds maximum width and padding behaviour for provided content, horizontally expanding to `infinity`.
     ///
-    /// A component can inspect the ``ScreenLayoutPaddingKey`` environment key to act upon this modifier.
+    /// A component can inspect the `screenLayoutPadding` environment key to act upon this modifier.
     /// One example is a `Card` component that ignores horizontal paddings in `compact` environment.
     ///
     /// - Parameters:


### PR DESCRIPTION
This fixes doc links to SwiftUI type extensions and removal (or commenting out) unused or obsolete types.