### PR TITLE
Fix `redacted` for `UIViewRepresentable` views

### DIFF
--- a/Sources/Orbit/Components/TextLink.swift
+++ b/Sources/Orbit/Components/TextLink.swift
@@ -39,6 +39,14 @@ public struct TextLink: UIViewRepresentable {
 
     private let content: NSAttributedString
     
+    private func resolvedLinkColor(in environment: EnvironmentValues) -> UIColor {
+        if #available(iOS 14, *), environment.redactionReasons.isEmpty == false {
+            return .clear
+        }
+
+        return textLinkColor?.value.uiColor ?? Color.primary.value.uiColor
+    }
+
     public func makeCoordinator() -> Coordinator {
         Coordinator(self)
     }
@@ -65,7 +73,7 @@ public struct TextLink: UIViewRepresentable {
         uiView.update(
             content: content,
             lineLimit: context.environment.lineLimit ?? 0,
-            color: textLinkColor?.value.uiColor ?? Color.primary.value.uiColor
+            color: resolvedLinkColor(in: context.environment)
         )
     }
     

--- a/Sources/Orbit/Support/TextFields/TextField.swift
+++ b/Sources/Orbit/Support/TextFields/TextField.swift
@@ -100,7 +100,7 @@ public struct TextField: UIViewRepresentable, TextFieldBuildable {
             context.coordinator.fontWeight = resolvedTextWeight
         }
 
-        uiView.updateIfNeeded(\.textColor, to: isEnabled ? (textColor ?? state.textColor).uiColor : .cloudDarkActive)
+        uiView.updateIfNeeded(\.textColor, to: resolvedTextColor(in: context.environment))
         uiView.updateIfNeeded(\.isEnabled, to: isEnabled)
 
         uiView.updateIfNeeded(
@@ -108,7 +108,7 @@ public struct TextField: UIViewRepresentable, TextFieldBuildable {
              to: .init(
                 string: prompt,
                 attributes: [
-                    .foregroundColor: isEnabled ? state.placeholderColor.uiColor : .cloudDarkActive
+                    .foregroundColor: resolvedPromptColor(in: context.environment)
                 ]
              )
         )
@@ -157,6 +157,22 @@ public struct TextField: UIViewRepresentable, TextFieldBuildable {
             inputFieldShouldChangeCharactersAction: inputFieldShouldChangeCharactersAction,
             inputFieldShouldChangeCharactersIdentifiableAction: inputFieldShouldChangeCharactersIdentifiableAction
         )
+    }
+
+    private func resolvedTextColor(in environment: EnvironmentValues) -> UIColor {
+        if #available(iOS 14, *), environment.redactionReasons.isEmpty == false {
+            return .clear
+        }
+
+        return isEnabled ? (textColor ?? state.textColor).uiColor : .cloudDarkActive
+    }
+
+    private func resolvedPromptColor(in environment: EnvironmentValues) -> UIColor {
+        if #available(iOS 14, *), environment.redactionReasons.isEmpty == false {
+            return .clear
+        }
+
+        return isEnabled ? state.placeholderColor.uiColor : .cloudDarkActive
     }
 
     private var resolvedTextSize: CGFloat {

--- a/Sources/Orbit/Support/TextFields/TextView.swift
+++ b/Sources/Orbit/Support/TextFields/TextView.swift
@@ -97,11 +97,11 @@ public struct TextView: UIViewRepresentable, TextFieldBuildable {
             context.coordinator.fontWeight = resolvedTextWeight
         }
 
-        uiView.updateIfNeeded(\.textColor, to: isEnabled ? (textColor ?? state.textColor).uiColor : .cloudDarkActive)
+        uiView.updateIfNeeded(\.textColor, to: resolvedTextColor(in: context.environment))
         uiView.updateIfNeeded(\.isEditable, to: isEnabled)
         uiView.updateIfNeeded(\.prompt, to: prompt)
-        uiView.updateIfNeeded(\.promptLabel.textColor, to: isEnabled ? state.placeholderColor.uiColor : .cloudDarkActive)
-        
+        uiView.updateIfNeeded(\.promptLabel.textColor, to: resolvedPromptColor(in: context.environment))
+
         // Check if the binding value is different to replace the text content
         if value != uiView.text {
             uiView.replace(withText: value)
@@ -146,6 +146,22 @@ public struct TextView: UIViewRepresentable, TextFieldBuildable {
             inputFieldShouldChangeCharactersAction: inputFieldShouldChangeCharactersAction,
             inputFieldShouldChangeCharactersIdentifiableAction: inputFieldShouldChangeCharactersIdentifiableAction
         )
+    }
+
+    private func resolvedTextColor(in environment: EnvironmentValues) -> UIColor {
+        if #available(iOS 14, *), environment.redactionReasons.isEmpty == false {
+            return .clear
+        }
+
+        return isEnabled ? (textColor ?? state.textColor).uiColor : .cloudDarkActive
+    }
+
+    private func resolvedPromptColor(in environment: EnvironmentValues) -> UIColor {
+        if #available(iOS 14, *), environment.redactionReasons.isEmpty == false {
+            return .clear
+        }
+
+        return isEnabled ? state.placeholderColor.uiColor : .cloudDarkActive
     }
 
     private var resolvedTextSize: CGFloat {


### PR DESCRIPTION
All SwiftUI components already worked with `redacted(...)`. The problem were those backed by UIKit - text would just show up. Fixed by setting the text to clear color if redaction is detected. The table illustrates most of the fixes.

| unredacted | redacted before fix | redacted after fix |
| ----------- | ------------------- | ------------------ |
| <img width="331" alt="unredacted" src="https://github.com/kiwicom/orbit-swiftui/assets/12349477/d5c29048-6420-4b8c-806f-675b1ca00d27"> | <img width="331" alt="redacted_before" src="https://github.com/kiwicom/orbit-swiftui/assets/12349477/c43464c0-1f1d-4102-9b33-c6f6fa556421"> | <img width="331" alt="redacted_after" src="https://github.com/kiwicom/orbit-swiftui/assets/12349477/4ae44202-618a-49f5-8721-57ef6a5f595c"> |

Closes #787.
