### PR TITLE
Localization breaks accessibility of some elements

### DIFF
--- a/Sources/Orbit/Components/InputField.swift
+++ b/Sources/Orbit/Components/InputField.swift
@@ -53,7 +53,6 @@ public struct InputField<Label: View, Prompt: View, Prefix: View, Suffix: View>:
     @Environment(\.inputFieldBeginEditingAction) private var inputFieldBeginEditingAction
     @Environment(\.inputFieldEndEditingAction) private var inputFieldEndEditingAction
     @Environment(\.isEnabled) private var isEnabled
-    @Environment(\.locale) private var locale
     @Environment(\.sizeCategory) private var sizeCategory
     @Environment(\.textColor) private var textColor
 
@@ -136,19 +135,19 @@ public struct InputField<Label: View, Prompt: View, Prefix: View, Suffix: View>:
             isFocused = false
             inputFieldEndEditingAction()
         }
-        .overlay(
-            resolvedPrompt, 
-            alignment: .leadingFirstTextBaseline
-        )
-        .accessibility {
+        .accessibility(children: nil) {
             label
         } value: {
             Text(value)
         } hint: {
-            Text(message?.description ?? "")
+            prompt
         }
+        .overlay(
+            resolvedPrompt, 
+            alignment: .leadingFirstTextBaseline
+        )
     }
-
+    
     @ViewBuilder private var secureTextRedactedButton: some View {
         if showSecureTextRedactedButton {
             IconButton(isSecureTextRedacted ? .visibility : .visibilityOff) {
@@ -178,6 +177,7 @@ public struct InputField<Label: View, Prompt: View, Prefix: View, Suffix: View>:
                 .lineLimit(1)
                 .padding(.horizontal, .small)
                 .allowsHitTesting(false)
+                .accessibility(hidden: true)
         }
     }
     

--- a/Sources/Orbit/Components/ListChoice.swift
+++ b/Sources/Orbit/Components/ListChoice.swift
@@ -118,7 +118,7 @@ public struct ListChoice<Icon: View, Title: View, Description: View, Header: Vie
             } hint: {
                 description
             }
-            .accessibility(addTraits: accessibilityTraitsToAdd)
+            .accessibility(addTraits: accessibilityTraits)
             .accessibility(.listChoice)
         }
     }
@@ -240,12 +240,12 @@ public struct ListChoice<Icon: View, Title: View, Description: View, Header: Vie
         title.isEmpty && description.isEmpty
     }
     
-    private var accessibilityTraitsToAdd: AccessibilityTraits {
+    private var accessibilityTraits: AccessibilityTraits {
         switch disclosure {
             case .none, .disclosure, .button(.add), .buttonLink, .checkbox(false, _), .radio(false, _), .icon:
-                return []
+                .isButton
             case .button(.remove), .checkbox(true, _), .radio(true, _):
-                return .isSelected
+                [.isButton, .isSelected]
         }
     }
     

--- a/Sources/Orbit/Components/Textarea.swift
+++ b/Sources/Orbit/Components/Textarea.swift
@@ -85,6 +85,13 @@ public struct Textarea<Label: View, Prompt: View>: View, TextFieldBuildable {
             isFocused = false
             inputFieldEndEditingAction()
         }
+        .accessibility(children: nil) {
+            label
+        } value: {
+            Text(value)
+        } hint: {
+            prompt
+        }
         .overlay(resolvedPrompt, alignment: .topLeading)
     }
     
@@ -94,6 +101,7 @@ public struct Textarea<Label: View, Prompt: View>: View, TextFieldBuildable {
                 .textColor(isEnabled ? state.placeholderColor : .cloudDarkActive)
                 .padding(.small)
                 .allowsHitTesting(false)
+                .accessibility(hidden: true)
         }
     }
     

--- a/Sources/Orbit/Support/Accessibility/AccessibilityLabelValueModifier.swift
+++ b/Sources/Orbit/Support/Accessibility/AccessibilityLabelValueModifier.swift
@@ -5,17 +5,26 @@ struct AccessibilityLabelValueModifier<Label: View, Value: View, Hint: View>: Vi
     @Environment(\.localizationBundle) private var localizationBundle
     @Environment(\.locale) private var locale
     
+    let childBehavior: AccessibilityChildBehavior?
     @ViewBuilder let label: Label
     @ViewBuilder let value: Value
     @ViewBuilder let hint: Hint
     
     func body(content: Content) -> some View {
         if isLabelTextual {
-            content
-                .accessibilityElement(children: .ignore)
-                .accessibility(label: textualLabel ?? SwiftUI.Text(""))
-                .accessibility(value: textualValue ?? SwiftUI.Text(""))
-                .accessibility(hint: textualHint ?? SwiftUI.Text(""))
+            if let childBehavior {
+                content
+                    .accessibilityElement(children: childBehavior)
+                    .accessibility(label: textualLabel ?? SwiftUI.Text(""))
+                    .accessibility(value: textualValue ?? SwiftUI.Text(""))
+                    .accessibility(hint: textualHint ?? SwiftUI.Text(""))
+
+            } else {
+                content
+                    .accessibility(label: textualLabel ?? SwiftUI.Text(""))
+                    .accessibility(value: textualValue ?? SwiftUI.Text(""))
+                    .accessibility(hint: textualHint ?? SwiftUI.Text(""))
+            }
         } else {
             content
                 .accessibilityElement(children: .contain)
@@ -42,10 +51,11 @@ struct AccessibilityLabelValueModifier<Label: View, Value: View, Hint: View>: Vi
 extension View {
     
     func accessibility<Label: View, Value: View, Hint: View>(
+        children: AccessibilityChildBehavior? = .ignore,
         @ViewBuilder label: () -> Label, 
         @ViewBuilder value: () -> Value = { EmptyView() },
         @ViewBuilder hint: () -> Hint = { EmptyView() }
     ) -> some View {
-        modifier(AccessibilityLabelValueModifier(label: label, value: value, hint: hint))
+        modifier(AccessibilityLabelValueModifier(childBehavior: children, label: label, value: value, hint: hint))
     }
 }

--- a/Sources/Orbit/Support/Accessibility/AccessibilityLabelValueModifier.swift
+++ b/Sources/Orbit/Support/Accessibility/AccessibilityLabelValueModifier.swift
@@ -10,7 +10,7 @@ struct AccessibilityLabelValueModifier<Label: View, Value: View, Hint: View>: Vi
     @ViewBuilder let hint: Hint
     
     func body(content: Content) -> some View {
-        if isLabelAndValueTextual {
+        if isLabelTextual {
             content
                 .accessibilityElement(children: .ignore)
                 .accessibility(label: textualLabel ?? SwiftUI.Text(""))
@@ -22,10 +22,8 @@ struct AccessibilityLabelValueModifier<Label: View, Value: View, Hint: View>: Vi
         }
     }
     
-    private var isLabelAndValueTextual: Bool {
-        textualLabel != nil 
-        && (textualValue != nil || value is EmptyView)
-        && (textualHint != nil || hint is EmptyView)
+    private var isLabelTextual: Bool {
+        textualLabel != nil
     }
     
     private var textualLabel: SwiftUI.Text? {


### PR DESCRIPTION
The "textfield" trait cannot be manually enforced. The solution is to only append the label, value and hint, without adding an accessibility container.