### PR TITLE
Improve support for form field accessibility to cover both single-acc…

### DIFF
--- a/Sources/Orbit/Components/Heading.swift
+++ b/Sources/Orbit/Components/Heading.swift
@@ -202,9 +202,7 @@ public extension Heading {
 extension Heading: TextRepresentable {
 
     public func text(environment: TextRepresentableEnvironment) -> SwiftUI.Text? {
-        content.isEmpty
-            ? nil
-            : textContent.text(environment: environment)
+        textContent.text(environment: environment)
     }
 }
 

--- a/Sources/Orbit/Components/Select.swift
+++ b/Sources/Orbit/Components/Select.swift
@@ -90,7 +90,7 @@ public struct Select<Label: View, Value: View, Prompt: View, Prefix: View, Suffi
         } value: {
             value
         } hint: {
-            Text(messageDescription)
+            SwiftUI.Text(messageDescription)
         }
         .accessibility(addTraits: .isButton)
         .accessibility(.select)

--- a/Sources/Orbit/Components/Text.swift
+++ b/Sources/Orbit/Components/Text.swift
@@ -497,9 +497,7 @@ enum TextLocalization {
 extension Text: TextRepresentable {
 
     public func text(environment: TextRepresentableEnvironment) -> SwiftUI.Text? {
-        isEmpty
-            ? nil
-            : text(environment: environment, showTextLinks: true)
+        text(environment: environment, showTextLinks: true)
     }
 }
 

--- a/Sources/Orbit/Support/Accessibility/AccessibilityLabelValueModifier.swift
+++ b/Sources/Orbit/Support/Accessibility/AccessibilityLabelValueModifier.swift
@@ -11,7 +11,7 @@ struct AccessibilityLabelValueModifier<Label: View, Value: View, Hint: View>: Vi
     @ViewBuilder let hint: Hint
     
     func body(content: Content) -> some View {
-        if isLabelTextual {
+        if isLabelOrValueTextual {
             if let childBehavior {
                 content
                     .accessibilityElement(children: childBehavior)
@@ -31,8 +31,8 @@ struct AccessibilityLabelValueModifier<Label: View, Value: View, Hint: View>: Vi
         }
     }
     
-    private var isLabelTextual: Bool {
-        textualLabel != nil
+    private var isLabelOrValueTextual: Bool {
+        textualLabel != nil || textualValue != nil
     }
     
     private var textualLabel: SwiftUI.Text? {

--- a/Sources/Orbit/Support/Forms/FieldMessage.swift
+++ b/Sources/Orbit/Support/Forms/FieldMessage.swift
@@ -20,6 +20,7 @@ public struct FieldMessage: View {
                 }
 
                 Text(message.description)
+                    .accessibility(.fieldMessage)
             }
             .iconColor(nil)
             .textColor(message.color)
@@ -33,6 +34,11 @@ public struct FieldMessage: View {
         self.message = message
         self.spacing = spacing
     }
+}
+
+// MARK: - Identifiers
+public extension AccessibilityID {
+    static let fieldMessage = Self(rawValue: "orbit.field.message")
 }
 
 // MARK: - Previews

--- a/Sources/Orbit/Support/Forms/FieldWrapper.swift
+++ b/Sources/Orbit/Support/Forms/FieldWrapper.swift
@@ -14,9 +14,6 @@ public struct FieldWrapper<Label: View, Content: View, Footer: View>: View {
         VStack(alignment: .leading, spacing: 0) {
             label
                 .textFontWeight(.medium)
-                // Component should expose label as part of content
-                .accessibility(hidden: true)
-                .accessibility(removeTraits: .isStaticText)
                 .padding(.bottom, .xxSmall)
 
             content

--- a/Sources/Orbit/Support/Forms/InputContent.swift
+++ b/Sources/Orbit/Support/Forms/InputContent.swift
@@ -32,9 +32,6 @@ public struct InputContent<Content: View, Label: View, Prefix: View, Suffix: Vie
                     .padding(.leading, .small)
                     .padding(.trailing, -.xxSmall)
                     .textColor(labelColor)
-                    // Component should expose label as part of content
-                    .accessibility(hidden: true)
-                    .accessibility(removeTraits: .isStaticText)
 
                 content
             }

--- a/Sources/Orbit/Support/Text/TextRepresentable.swift
+++ b/Sources/Orbit/Support/Text/TextRepresentable.swift
@@ -270,6 +270,7 @@ extension View {
     func text(locale: Locale, localizationBundle: Bundle) -> SwiftUI.Text? {
         switch self {
             case let text as SwiftUI.Text:          text
+            case let value as SelectValue:          value.value.map(SwiftUI.Text.init)
             case let text as TextRepresentable:     text.text(environment: .init(locale: locale, localizationBundle: localizationBundle))
             default:                                nil
         }


### PR DESCRIPTION
The update should make it closer to native behaviour:
1) when simple text-based components are provided, the component acts as a single accessibility element with "label", "value" and "hint" filled in
2) when custom components are provided, the component acts as an accessibility wrapper over the existing separate accessibility elements.

Tested against the app UI tests.